### PR TITLE
Update/openfoam - part 1

### DIFF
--- a/OpenFOAM/basicInstallations/openfoam-2.2.0/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-2.2.0/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 16.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu16.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu16.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-2.2.0/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-2.2.0/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 16.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu16.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu16.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-2.2.0/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-2.2.0/02_PortingToSingularity/Singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: pawsey/openfoam:2.2.0
+From: quay.io/pawsey/openfoam:2.2.0
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/basicInstallations/openfoam-2.4.x/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-2.4.x/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base image to build from
 # In this case: mpich 3.1.4 and ubuntu 16.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu16.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu16.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-2.4.x/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-2.4.x/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base image to build from
 # In this case: mpich 3.1.4 and ubuntu 16.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu16.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu16.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-2.4.x/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-2.4.x/02_PortingToSingularity/Singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: pawsey/openfoam:2.4.x
+From: quay.io/pawsey/openfoam:2.4.x
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/basicInstallations/openfoam-5.x/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-5.x/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base image to build from
 # In this case: mpich 3.1.4 and ubuntu 16.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu16.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu16.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-5.x/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-5.x/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base image to build from
 # In this case: mpich 3.1.4 and ubuntu 16.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu16.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu16.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-5.x/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-5.x/02_PortingToSingularity/Singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: pawsey/openfoam:5.x
+From: quay.io/pawsey/openfoam:5.x
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/basicInstallations/openfoam-7/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-7/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-7/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-7/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-7/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-7/02_PortingToSingularity/Singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: pawsey/openfoam:7
+From: quay.io/pawsey/openfoam:7
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/basicInstallations/openfoam-8/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-8/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-8/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-8/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-8/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-8/02_PortingToSingularity/Singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: pawsey/openfoam:8
+From: quay.io/pawsey/openfoam:8
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/basicInstallations/openfoam-v1712/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v1712/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v1712/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v1712/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v1712/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-v1712/02_PortingToSingularity/Singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: pawsey/openfoam:v1712
+From: quay.io/pawsey/openfoam:v1712
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/basicInstallations/openfoam-v1812/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v1812/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v1812/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v1812/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v1812/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-v1812/02_PortingToSingularity/Singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: pawsey/openfoam:v1812
+From: quay.io/pawsey/openfoam:v1812
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/basicInstallations/openfoam-v1912/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v1912/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v1912/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v1912/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v1912/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-v1912/02_PortingToSingularity/Singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: pawsey/openfoam:v1912
+From: quay.io/pawsey/openfoam:v1912
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/basicInstallations/openfoam-v2006/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v2006/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v2006/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v2006/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v2006/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-v2006/02_PortingToSingularity/Singularity.def
@@ -1,6 +1,6 @@
 #Bootstrap: docker
 Bootstrap: docker-daemon
-From: pawsey/openfoam:v2006
+From: quay.io/pawsey/openfoam:v2006
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/basicInstallations/openfoam-v2012/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v2012/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v2012/01_Docker/Dockerfile
+++ b/OpenFOAM/basicInstallations/openfoam-v2012/01_Docker/Dockerfile
@@ -4,7 +4,7 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM pawsey/mpich-base:3.1.4_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.1.4_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/basicInstallations/openfoam-v2012/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/basicInstallations/openfoam-v2012/02_PortingToSingularity/Singularity.def
@@ -1,6 +1,6 @@
 Bootstrap: docker
 #Bootstrap: docker-daemon
-From: pawsey/openfoam:v2012
+From: quay.io/pawsey/openfoam:v2012
 
 %post
 /bin/mv /bin/sh /bin/sh.original

--- a/OpenFOAM/installationsWithAdditionalTools/openfoam-5.x_CFDEM/01_Docker/Dockerfile
+++ b/OpenFOAM/installationsWithAdditionalTools/openfoam-5.x_CFDEM/01_Docker/Dockerfile
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------
 #The creation of this image that contains VTK, LIGGGHTS && CFDEM starts
 #from the already existing and working image of openfoam:5.x
-FROM pawsey/openfoam:5.x
+FROM quay.io/pawsey/openfoam:5.x
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install
 ARG OFVERSION="5.x"

--- a/OpenFOAM/installationsWithAdditionalTools/openfoam-5.x_CFDEM/02_PortingToSingularity/Singularity.def
+++ b/OpenFOAM/installationsWithAdditionalTools/openfoam-5.x_CFDEM/02_PortingToSingularity/Singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: pawsey/openfoam:5.x_CFDEM
+From: quay.io/pawsey/openfoam:5.x_CFDEM
 
 %post
 /bin/mv /bin/sh /bin/sh.original


### PR DESCRIPTION
@AlexisEspinosaGayosso , 
this is a first set of general updates to the openfoam recipes, essentially:
- refer to pawsey containers in RedHat Quay (`quay.io/pawsey/`), instead of Docker Hub
- update to more recent MPI base images, using MPICH version `3.4.3`

 