### PR TITLE
Updating v1912 & v2006 recipies to Ubuntu20.04

### DIFF
--- a/OpenFOAM/openfoam-org/10/Dockerfile
+++ b/OpenFOAM/openfoam-org/10/Dockerfile
@@ -3,6 +3,8 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam-org/2.2.0/Dockerfile
+++ b/OpenFOAM/openfoam-org/2.2.0/Dockerfile
@@ -2,9 +2,32 @@
 #---------------------------------------------------------------
 #---------------------------------------------------------------
 # 0. Initial main definition
-# Defining the base container to build from
-# In this case: mpich 3.1.4 and ubuntu 16.04; MPICH is needed for crays
+# Defining the base image to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
+# FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
+# IMPORTANT:
+# Unfortunately current recipe does not compile correctly on ubuntu20.04,
+# So, this recipe is left to use ubuntu16.04 as a starting point for further development.
+# This recipe compiles and may run properly elsewhere, but will not run properly on Setonix anymore.
+# For this reason, the docker image has been moved to the openfoam-legacy-2021 repository in quay.io .
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu16.04
+# IMPORTANT:
+# Therefore, this recipe needs to be modified to be able to compile with ubuntu20.04
+# in order to be used on Setonix. This furher effort is left to users, and Pawsey will not put
+# additional effort on this, as the OpenFOAM version is rather old.
+# Problems that have been identified are:
+# -Ubuntu20.04 does not have apt-get install for QT4 related libraries
+#      + Possible solutions: = find another way for installing old QT4 libraries,
+#                            or
+#                            = switch to use equivalent QT5 libraries
+# -Ubuntu20.04 does not have apt-get install for the old compiler gcc-5
+#      + Possible solutions: = find another way for installing old gcc-5 compiler,
+#                            or
+#                            = swicth to the use the oldest possible compiler (like gcc-7)
+#                              and perform changes in compiler configuration/code in order
+#                              to allow proper compilation
+#
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/openfoam-org/2.4.x/Dockerfile
+++ b/OpenFOAM/openfoam-org/2.4.x/Dockerfile
@@ -3,9 +3,31 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base image to build from
-# In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays, 18.04 is needed for Setonix
-# Note that in 18.04 we'll need to install and force compilation with gcc-5,g++-5.
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
+# FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
+# IMPORTANT:
+# Unfortunately current recipe does not compile correctly on ubuntu20.04,
+# So, this recipe is left to use ubuntu18.04 as a starting point for further development.
+# This recipe compiles and may run properly elsewhere, but will not run properly on Setonix anymore.
+# For this reason, the docker image has been moved to the openfoam-legacy-2022 repository in quay.io .
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
+# IMPORTANT:
+# Therefore, this recipe needs to be modified to be able to compile with ubuntu20.04
+# in order to be used on Setonix. This furher effort is left to users, and Pawsey will not put
+# additional effort on this, as the OpenFOAM version is rather old.
+# Problems that have been identified are:
+# -Ubuntu20.04 does not have apt-get install for QT4 related libraries
+#      + Possible solutions: = find another way for installing old QT4 libraries,
+#                            or
+#                            = switch to use equivalent QT5 libraries
+# -Ubuntu20.04 does not have apt-get install for the old compiler gcc-5
+#      + Possible solutions: = find another way for installing old gcc-5 compiler,
+#                            or
+#                            = swicth to the use the oldest possible compiler (like gcc-7)
+#                              and perform changes in compiler configuration/code in order
+#                              to allow proper compilation
+#
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/openfoam-org/5.x/Dockerfile
+++ b/OpenFOAM/openfoam-org/5.x/Dockerfile
@@ -3,9 +3,31 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base image to build from
-# In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays, 18.04 is needed for Setonix
-#Note that in 18.04 we'll need to install and force compilation with gcc-5,g++-5
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
+# FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
+# IMPORTANT:
+# Unfortunately current recipe does not compile correctly on ubuntu20.04,
+# So, this recipe is left to use ubuntu18.04 as a starting point for further development.
+# This recipe compiles and may run properly elsewhere, but will not run properly on Setonix anymore.
+# For this reason, the docker image has been moved to the openfoam-legacy-2022 repository in quay.io .
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
+# IMPORTANT:
+# Therefore, this recipe needs to be modified to be able to compile with ubuntu20.04
+# in order to be used on Setonix. This furher effort is left to users, and Pawsey will not put
+# additional effort on this, as the OpenFOAM version is rather old.
+# Problems that have been identified are:
+# -Ubuntu20.04 does not have apt-get install for QT4 related libraries
+#      + Possible solutions: = find another way for installing old QT4 libraries,
+#                            or
+#                            = switch to use equivalent QT5 libraries
+# -Ubuntu20.04 does not have apt-get install for the old compiler gcc-5
+#      + Possible solutions: = find another way for installing old gcc-5 compiler,
+#                            or
+#                            = swicth to the use the oldest possible compiler (like gcc-7)
+#                              and perform changes in compiler configuration/code in order
+#                              to allow proper compilation
+#
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install

--- a/OpenFOAM/openfoam-org/7/Dockerfile
+++ b/OpenFOAM/openfoam-org/7/Dockerfile
@@ -3,6 +3,8 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam-org/8/Dockerfile
+++ b/OpenFOAM/openfoam-org/8/Dockerfile
@@ -3,6 +3,8 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam-org/9/Dockerfile
+++ b/OpenFOAM/openfoam-org/9/Dockerfile
@@ -3,6 +3,8 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam/v1712/Dockerfile
+++ b/OpenFOAM/openfoam/v1712/Dockerfile
@@ -3,7 +3,17 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
-# In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
+# FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
+# IMPORTANT:
+# Because this version of OpenFOAM is too old, Pawsey has decided to not
+# keep maintaining updates for it. So, update to ubuntu20.04 has not been tested yet.
+# For this reason the image has been removed from main repository in quay.io and moved to
+# the openfoam-legacy-2022 repository.
+# IMPORTANT:
+# Current recipe compiles fine, and may run elsewhere, but will not run properly on Setonix.
+# Update, rebuild and testing is left to users in need for this version of OpenFOAM to run on Setonix.
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam/v1812/Dockerfile
+++ b/OpenFOAM/openfoam/v1812/Dockerfile
@@ -3,7 +3,17 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
-# In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
+# FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
+# IMPORTANT:
+# Because this version of OpenFOAM is too old, Pawsey has decided to not
+# keep maintaining updates for it. So, update to ubuntu20.04 has not been tested yet.
+# For this reason the image has been removed from main repository in quay.io and moved to
+# the openfoam-legacy-2022 repository.
+# IMPORTANT:
+# Current recipe compiles fine, and may run elsewhere, but will not run properly on Setonix.
+# Update, rebuild and testing is left to users in need for this version of OpenFOAM to run on Setonix.
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam/v1912/Dockerfile
+++ b/OpenFOAM/openfoam/v1912/Dockerfile
@@ -3,6 +3,8 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam/v1912/Dockerfile
+++ b/OpenFOAM/openfoam/v1912/Dockerfile
@@ -3,8 +3,7 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
-# In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install
@@ -64,6 +63,12 @@ RUN echo "ofuser:${OFVERSION}" | chpasswd
 #https://openfoamwiki.net/index.php/Installation/Linux/OpenFOAM-v1806/Ubuntu
 #
 #Then, Will follow a combination of both
+#There are other official instructions (but will not follow them now):
+#https://develop.openfoam.com/Development/openfoam/-/wikis/building
+#and
+#https://develop.openfoam.com/Development/openfoam/blob/develop/doc/Build.md
+#and
+#https://develop.openfoam.com/Development/openfoam/blob/develop/doc/Requirements.md
 
 #...........
 #Definition of the installation directory within the container
@@ -89,12 +94,13 @@ RUN apt-get update -qq\
 #AEG:No OpenMPI because MPICH will be used (installed in the parent FROM image)
 #AEG:NoOpenMPI:   libopenmpi-dev openmpi-bin \
    gnuplot libreadline-dev libncurses-dev libxt-dev \
-#AEG:Not installing qt4 (as in the official instructions), but qt5 as in the wiki instructions
-#AEG:NoQt4:   qt4-dev-tools libqt4-dev libqt4-opengl-dev \ 
-   qt5-default libqt5x11extras5-dev libqt5help5 qtdeclarative5-dev qttools5-dev libqt5opengl5-dev \
-   freeglut3-dev libqtwebkit-dev \
-#AEG:Wiki additional qt suggestions (from OpenFOAM-7):
-   qtbase5-dev \
+#AEG:NoQt4:   qt4-dev-tools libqt4-dev libqt4-opengl-dev libqtwebkit-dev\ 
+#AEG:Not installing qt4 (as in the official instructions), but qt5 as in the 3rd party requirements list
+   qtbase5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libqt5x11extras5-dev libxt-dev \
+#AEG:And these other suggested in the wiki:
+   qt5-default libqt5help5 qtdeclarative5-dev \
+#--continue
+   freeglut3-dev  \
 #AEG:No scotch because it installs openmpi which later messes up with MPICH
 #    Therefore, ThirdParty scotch is the one to be installed and used by openfoam.
 #AEG:NoScotch:   libscotch-dev \
@@ -109,7 +115,6 @@ RUN apt-get update -qq\
    libfl-dev \
  && apt-get clean all \
  && rm -r /var/lib/apt/lists/*
-
 
 #...........
 #Step 2. Download
@@ -170,8 +175,9 @@ RUN head -23 ${OFINSTDIR}/OpenFOAM-${OFVERSION}/etc/config.sh/example/prefs.sh >
 #Modifying the bashrc file
 RUN cp ${OFBASHRC} ${OFBASHRC}.original \
 #Changing the installation directory within the bashrc file (This is not in the openfoamwiki instructions)
- && sed -i '/^projectDir="$HOME.*/aprojectDir="'"${OFINSTDIR}"'/OpenFOAM-$WM_PROJECT_VERSION"' ${OFBASHRC} \
- && sed -i '0,/^projectDir="$HOME/s//# projectDir="$HOME/' ${OFBASHRC} \
+ && sed -i 's/^projectDir=/# projectDir=/g' ${OFBASHRC} \
+ && sed -i '0,/\[ -n "$projectDir"/s//# \[ -n "$projectDir"/' ${OFBASHRC} \
+ && sed -i '0,/^# projectDir="$HOME.*/!b;//a\projectDir="'"${OFINSTDIR}"'/OpenFOAM-$WM_PROJECT_VERSION"' ${OFBASHRC} \
 #" (This comment line is needed to let vi to show the right syntax)
 #Changing the place for your own tools/solvers (WM_PROJECT_USER_DIR directory) within the bashrc file 
 #IMPORTANT:When using this container, you have two options when building your own tools/solvers:

--- a/OpenFOAM/openfoam/v2006/Dockerfile
+++ b/OpenFOAM/openfoam/v2006/Dockerfile
@@ -3,8 +3,7 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
-# In this case: mpich 3.1.4 and ubuntu 18.04; MPICH is needed for crays
-FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu18.04
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install
@@ -65,6 +64,12 @@ RUN echo "ofuser:${OFVERSION}" | chpasswd
 #(There are some other instructions for v1906, but not for ubuntu)
 #
 #Then, Will follow a combination of both
+#There are other official instructions (but will not follow them now):
+#https://develop.openfoam.com/Development/openfoam/-/wikis/building
+#and
+#https://develop.openfoam.com/Development/openfoam/blob/develop/doc/Build.md
+#and
+#https://develop.openfoam.com/Development/openfoam/blob/develop/doc/Requirements.md
 
 #...........
 #Definition of the installation directory within the container
@@ -90,12 +95,13 @@ RUN apt-get update -qq\
 #AEG:NoOpenMPI:   libopenmpi-dev openmpi-bin \
    libfftw3-dev \
    gnuplot libreadline-dev libncurses-dev libxt-dev \
-#AEG:Not installing qt4 (as in the official instructions), but qt5 as in the wiki instructions
-#AEG:NoQt4:   qt4-dev-tools libqt4-dev libqt4-opengl-dev \ 
-   qt5-default libqt5x11extras5-dev libqt5help5 qtdeclarative5-dev qttools5-dev libqt5opengl5-dev \
-   freeglut3-dev libqtwebkit-dev \
-#AEG:Wiki additional qt suggestions (from OpenFOAM-7):
-   qtbase5-dev \
+#AEG:NoQt4:   qt4-dev-tools libqt4-dev libqt4-opengl-dev libqtwebkit-dev\ 
+#AEG:Not installing qt4 (as in the official instructions), but qt5 as in the 3rd party requirements list
+   qtbase5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libqt5x11extras5-dev libxt-dev \
+#AEG:And these other suggested in the wiki:
+   qt5-default libqt5help5 qtdeclarative5-dev \
+#--continue
+   freeglut3-dev  \
 #AEG:No scotch because it installs openmpi which later messes up with MPICH
 #    Therefore, ThirdParty scotch is the one to be installed and used by openfoam.
 #AEG:NoScotch:   libscotch-dev \
@@ -170,8 +176,9 @@ RUN head -23 ${OFINSTDIR}/OpenFOAM-${OFVERSION}/etc/config.sh/example/prefs.sh >
 #Modifying the bashrc file
 RUN cp ${OFBASHRC} ${OFBASHRC}.original \
 #Changing the installation directory within the bashrc file (This is not in the openfoamwiki instructions)
- && sed -i '/^projectDir="$HOME.*/aprojectDir="'"${OFINSTDIR}"'/OpenFOAM-$WM_PROJECT_VERSION"' ${OFBASHRC} \
- && sed -i '0,/^projectDir="$HOME/s//# projectDir="$HOME/' ${OFBASHRC} \
+ && sed -i 's/^projectDir=/# projectDir=/g' ${OFBASHRC} \
+ && sed -i '0,/\[ -n "$projectDir"/s//# \[ -n "$projectDir"/' ${OFBASHRC} \
+ && sed -i '0,/^# projectDir="$HOME.*/!b;//a\projectDir="'"${OFINSTDIR}"'/OpenFOAM-$WM_PROJECT_VERSION"' ${OFBASHRC} \
 #" (This comment line is needed to let vi to show the right syntax)
 #Changing the place for your own tools/solvers (WM_PROJECT_USER_DIR directory) within the bashrc file 
 #IMPORTANT:When using this container, you have two options when building your own tools/solvers:

--- a/OpenFOAM/openfoam/v2006/Dockerfile
+++ b/OpenFOAM/openfoam/v2006/Dockerfile
@@ -3,6 +3,8 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam/v2012/Dockerfile
+++ b/OpenFOAM/openfoam/v2012/Dockerfile
@@ -3,6 +3,8 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam/v2206/Dockerfile
+++ b/OpenFOAM/openfoam/v2206/Dockerfile
@@ -3,6 +3,8 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"

--- a/OpenFOAM/openfoam/v2212/Dockerfile
+++ b/OpenFOAM/openfoam/v2212/Dockerfile
@@ -3,6 +3,8 @@
 #---------------------------------------------------------------
 # 0. Initial main definition
 # Defining the base container to build from
+# IMPORTANT: 
+# Setonix needs at least ubuntu20.04 (From August 2023)
 FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"


### PR DESCRIPTION
These recipes have been updated to use ubuntu 20.04, fixed to be able to build properly and containers have been successfully tested in Joey for a tutorial case from their own versions. All good with this two versions of OpenFOAM containers.