### PR TITLE
Update buildlustrempich.dockerfile

### DIFF
--- a/mpi/lustrempich-base/buildlustrempich.dockerfile
+++ b/mpi/lustrempich-base/buildlustrempich.dockerfile
@@ -78,7 +78,9 @@ RUN echo "Building lustre" \
     && cd /tmp/lustre-build \
     && git clone git://git.whamcloud.com/fs/lustre-release.git \
     && cd lustre-release \
-    && git fetch --tags && git checkout ${LUSTRE_VERSION} \
+    # there appears to be an odd error with some release not being able to configure. 
+    # for the moment, just use the main branch rather than a particular version.
+    # && git fetch --tags && git checkout ${LUSTRE_VERSION} \
     && chmod +x ./autogen.sh && ./autogen.sh \
     && ./configure --disable-server --enable-client \
     && make -j8 && make install \


### PR DESCRIPTION
Minor update to not use a specific branch of lustre in the recipe. Oddly, there are a number of versions that do not properly build. So for now, just build main