### PR TITLE
Bumps PyTorch version, install torchvision and other libs.

### DIFF
--- a/pytorch/pytorch.dockerfile
+++ b/pytorch/pytorch.dockerfile
@@ -7,6 +7,7 @@ ENV CXX=g++
 ENV CC=gcc
 ENV CXXFLAGS=-std=c++17
 ENV PYTORCH_ROCM_ARCH=gfx90a	
+ENV LD_LIBRARY_PATH=/opt/rocm/llvm/lib:$LD_LIBRARY_PATH
 
 RUN	apt -y install libopenblas-dev "libpng*" "libjpeg-turbo*" libjpeg-dev libpng-dev \
 	&& (! [ -e /tmp/build ] || rm -rf /tmp/build) \
@@ -21,8 +22,12 @@ RUN	apt -y install libopenblas-dev "libpng*" "libjpeg-turbo*" libjpeg-dev libpng
 	&& make -j 16 \
 	&& make install
 
+RUN     pip3 install mpmath urllib3 typing-extensions sympy pillow numpy networkx MarkupSafe idna fsspec filelock charset-normalizer certifi requests pytorch-triton-rocm jinja2 --index-url https://download.pytorch.org/whl/rocm5.6 --no-dependencies
+
+ENV ROCM_PATH=/opt/rocm
+
 RUN	cd /tmp/build \
-	&& git clone --branch v2.1.2 --recursive https://github.com/pytorch/pytorch \
+	&& git clone --branch v2.2.0 --recursive https://github.com/pytorch/pytorch \
 	&& cd pytorch \
 	&& grep -R . -e "MPI_CXX" | cut -f1 -d: | xargs -n1 sed -i -e "s/MPI_CXX/MPI_C/g" \
 	# if you are updating an existing checkout \
@@ -32,16 +37,36 @@ RUN	cd /tmp/build \
 	&& sed -i -e '270d' -e '269a ON)' CMakeLists.txt \
 	# Install deps	
 	&& python3 -m pip install -r requirements.txt \
+        && sed -i -e '3d' -e '2 a pip install --index-url https://download.pytorch.org/whl/nightly/ "pytorch-triton==2.2.0+e28a256d71" ' scripts/install_triton_wheel.sh\
 	&& make triton\
 	&& python3 tools/amd_build/build_amd.py\
 	&& python3 setup.py install 
 
 # Install torch vision
 RUN     cd /tmp/build \
-        && git clone --branch v0.16.2 https://github.com/pytorch/vision.git \
+        && git clone --branch v0.17.0 https://github.com/pytorch/vision.git \
         && cd vision \
         && python3 setup.py install
 
-RUN     pip3 install mpmath urllib3 typing-extensions sympy pillow numpy networkx MarkupSafe idna fsspec filelock charset-normalizer certifi requests pytorch-triton-rocm jinja2 torchaudio  --index-url https://download.pytorch.org/whl/rocm5.6 --no-dependencies
+# Install torch audio
+ARG CXX=hipcc
+ARG ROCRAND_PATH=/opt/rocm
+ARG HIPRAND_PATH=/opt/rocm
+ARG ROCBLAS_PATH=/opt/rocm
+ARG MIOPEN_PATH=/opt/rocm
+ARG ROCFFT_PATH=/opt/rocm
+ARG HIPFFT_PATH=/opt/rocm
+ARG HIPSPARSE_PATH=/opt/rocm
+ARG RCCL_PATH=/opt/rocm
+ARG ROCPRIM_PATH=/opt/rocm
+ARG HIPCUB_PATH=/opt/rocm
+ARG ROCTHRUST_PATH=/opt/rocm
+
+RUN     cd /tmp/build \
+        && git clone --branch v2.2.0 https://github.com/pytorch/audio.git \
+        && cd audio \
+        && sed -i '149,150d' cmake/LoadHIP.cmake \
+        && python3 setup.py install
+
 
 RUN	[ -e /tmp/build ] && rm -rf /tmp/build

--- a/pytorch/pytorch.dockerfile
+++ b/pytorch/pytorch.dockerfile
@@ -8,7 +8,7 @@ ENV CC=gcc
 ENV CXXFLAGS=-std=c++17
 ENV PYTORCH_ROCM_ARCH=gfx90a	
 
-RUN	apt -y install libopenblas-dev \
+RUN	apt -y install libopenblas-dev "libpng*" "libjpeg-turbo*" libjpeg-dev libpng-dev \
 	&& (! [ -e /tmp/build ] || rm -rf /tmp/build) \
 	&& mkdir /tmp/build && cd /tmp/build \
 	# install eigen
@@ -22,7 +22,7 @@ RUN	apt -y install libopenblas-dev \
 	&& make install
 
 RUN	cd /tmp/build \
-	&& git clone --branch v2.1.0 --recursive https://github.com/pytorch/pytorch \
+	&& git clone --branch v2.1.2 --recursive https://github.com/pytorch/pytorch \
 	&& cd pytorch \
 	&& grep -R . -e "MPI_CXX" | cut -f1 -d: | xargs -n1 sed -i -e "s/MPI_CXX/MPI_C/g" \
 	# if you are updating an existing checkout \
@@ -35,5 +35,13 @@ RUN	cd /tmp/build \
 	&& make triton\
 	&& python3 tools/amd_build/build_amd.py\
 	&& python3 setup.py install 
-	
+
+# Install torch vision
+RUN     cd /tmp/build \
+        && git clone --branch v0.16.2 https://github.com/pytorch/vision.git \
+        && cd vision \
+        && python3 setup.py install
+
+RUN     pip3 install mpmath urllib3 typing-extensions sympy pillow numpy networkx MarkupSafe idna fsspec filelock charset-normalizer certifi requests pytorch-triton-rocm jinja2 torchaudio  --index-url https://download.pytorch.org/whl/rocm5.6 --no-dependencies
+
 RUN	[ -e /tmp/build ] && rm -rf /tmp/build


### PR DESCRIPTION
Install other PyTorch libraries that are often needed. Installation can be tricky for users, as they need to get the prebuilt binaries from the correct (nondefault) repository, or build from source.