### PR TITLE
Build Qiskit for Grace Hopper (#50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,80 @@ out_*
 nohup.out
 *.tgz
 log.*
+
+# Virtualenv
+/.venv/
+/venv/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+/bin/
+/build/
+/develop-eggs/
+/dist/
+/eggs/
+/lib/
+/lib64/
+/output/
+/parts/
+/sdist/
+/var/
+/*.egg-info/
+/.installed.cfg
+/*.egg
+/.eggs
+
+# AUTHORS and ChangeLog will be generated while packaging
+/AUTHORS
+/ChangeLog
+
+# BCloud / BuildSubmitter
+/build_submitter.*
+/logger_client_log
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+.tox/
+.coverage
+.cache
+.pytest_cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Sphinx documentation
+/docs/_build/
+
+# Study test
+/study/
+
+# JetBrains
+/.idea/
+/.run/
+
+Output/
+/Calibration/
+
+.DS_Store
+
+# Jupyter Notebook
+/PatentResearch/.ipynb_checkpoints/
+
+# log files
+/ModelEvaluation/log/
+Example/
+*/Output/
+
+# Environmental variables
+.run/__init__.run.xml

--- a/applications/qiskit/buildqiskit-cuda-aarch64.dockerfile
+++ b/applications/qiskit/buildqiskit-cuda-aarch64.dockerfile
@@ -1,0 +1,131 @@
+# This recipe supports Qiskit-aer-GPU built with a minimal image based on CUDA 12.5, compatible with Grace Hopper, and supporting aarch64 architectures.
+# NO MPI, NO LUSTRE, NO
+# py version is allowed to be passed in as a build argument
+ARG PY_VERSION="3.12" 
+# cuda version is allowed to be passed in as a build argument 12.5.0/12.6.0. For Grace Hopper, we recommand only these two versions.
+ARG CUDA_VERSION="12.5.0"
+# date tag is allowed to be passed in as a build argument
+ARG DATE_TAG=2024-09
+
+#----------------------------------------------------------------
+#------------------------start stage------------------------
+#----------------------------------------------------------------
+FROM ubuntu:22.04
+ARG PY_VERSION 
+ARG DATE_TAG
+ARG CUDA_VERSION
+
+
+# define some metadata 
+LABEL org.opencontainers.image.created="2024-09"
+LABEL org.opencontainers.image.authors="Shusen Liu <shusen.liu@pawsey.org.au>"
+LABEL org.opencontainers.image.documentation="https://github.com/PawseySC/pawsey-containers/"
+LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers/applications/qiskit/buildqiskit-cuda.dockerfile"
+LABEL org.opencontainers.image.vendor="Pawsey Supercomputing Research Centre"
+LABEL org.opencontainers.image.licenses="GNU GPL3.0"
+LABEL org.opencontainers.image.title="Qiskit - Grace Hopper with CUDA ${CUDA_VERSION}"
+LABEL org.opencontainers.image.description="A Qiskit-aer-GPU built with a minimal image based on CUDA 12.5, compatible with Grace Hopper, and supporting aarch64 architectures."
+LABEL org.opencontainers.image.base.name="ubuntu2204"
+
+# run apt-get install on a few packages
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends software-properties-common gpg-agent \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        wget \
+        git \
+        python3 python3-dev python3-pip python3-setuptools python3-venv \
+        sudo \
+        curl \
+        libtool \
+        make \
+        cmake \
+        openssh-server \
+        vim \
+        ninja-build \
+        libblas-dev libopenblas-dev \
+        python${PY_VERSION}-dev \
+        python${PY_VERSION}-distutils \
+        python${PY_VERSION}-full \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-keyring_1.1-1_all.deb \
+    && dpkg -i cuda-keyring_1.1-1_all.deb \
+    && apt-get update \
+    && if [ "${CUDA_VERSION}" = "12.5.0" ]; then \
+           apt-get -y install cuda-compiler-12-5; \
+       elif [ "${CUDA_VERSION}" = "12.6.0" ]; then \
+           apt-get -y install cuda-compiler-12-6; \
+       else \
+           echo "Unsupported CUDA version: ${CUDA_VERSION}"; \
+           exit 1; \
+       fi \
+    && pip install --upgrade pip setuptools \
+    && pip install nvidia-cuda-runtime-cu12 nvidia-nvjitlink-cu12 nvidia-cublas-cu12 nvidia-cusolver-cu12 nvidia-cusparse-cu12 pip-tools \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python${PY_VERSION} 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PY_VERSION} 1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm cuda-keyring_1.1-1_all.deb
+
+WORKDIR /opt/
+
+RUN wget https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-sbsa/cuquantum-linux-sbsa-24.08.0.5_cuda12-archive.tar.xz -O cuquantum.tar.xz \
+  && wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.0.2.5-archive.tar.xz -O libcutensor.tar.xz \
+  && tar -xf cuquantum.tar.xz \
+  && tar -xf libcutensor.tar.xz \
+  && ls  \
+  && mv cuquantum-linux* /opt/cuquantum \
+  && mv libcutensor-linux* /opt/libcutensor \
+  && mkdir -p /opt/cuquantum/lib/12 \
+  && cd /opt/cuquantum/lib \
+  && for file in *; do ln -s ../$file 12/$file; done \
+  && rm /opt/cuquantum.tar.xz /opt/libcutensor.tar.xz
+
+RUN mkdir -p /opt/qiskit-aer-build \
+  && git clone https://github.com/Qiskit/qiskit-aer /opt/qiskit-aer-build \
+  && cd /opt/qiskit-aer-build \
+  ## Only 0.15 For Grace Hopper
+  && git checkout 0.15  
+
+RUN echo "Building Qiskit ... " \
+    && python -m ensurepip --upgrade \
+    && python -m pip install --upgrade setuptools
+
+RUN pip --no-cache-dir install  scikit-build>=0.11.0 conan==1.65.0 pybind11==2.13.4 numpy==2.0.1
+
+# set the default Python version
+RUN if [ ! -e /usr/bin/python ]; then ln -s /usr/bin/python3 /usr/bin/python; fi
+
+RUN rm -rf /opt/qiskit-aer-build/_skbuild
+
+ENV CC=/usr/bin/gcc \
+    CXX=/usr/bin/g++ \
+    CUDACXX=/usr/local/cuda/bin/nvcc
+
+WORKDIR /opt/qiskit-aer-build
+ENV LD_LIBRARY_PATH=/opt/cuquantum/lib:/usr/local/lib/python3.10/dist-packages/nvidia/cublas/lib:/opt/libcutensor/lib/12:/usr/local/lib/python3.10/dist-packages/nvidia/cusolver/lib:/usr/local/lib/python3.10/dist-packages/nvidia/cusparse/lib:${LD_LIBRARY_PATH:-""}
+
+RUN  python ./setup.py bdist_wheel -vvv --  \
+    -DAER_THRUST_BACKEND=CUDA \
+    -DCUQUANTUM_ROOT=/opt/cuquantum \
+    -DCUTENSOR_ROOT=/opt/libcutensor \
+    -DAER_ENABLE_CUQUANTUM=true
+ 
+# install qiskit-aer
+RUN python -m pip install /opt/qiskit-aer-build/dist/qiskit_aer*.whl
+
+RUN rm -rf /opt/qiskit-aer-build/_skbuild
+#RUN python -m pip install -r /opt/qiskit-aer-build/requirements-dev.txt
+
+RUN mkdir -p /container-scratch/
+
+# and copy the recipe into the docker recipes directory
+RUN mkdir -p /opt/docker-recipes/
+COPY buildqiskit-cuda.dockerfile /opt/docker-recipes/
+
+# final
+CMD ["/bin/bash"]   

--- a/cuda/cuda-lustre-mpich/build.sh
+++ b/cuda/cuda-lustre-mpich/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Get today's date in yyyy/mm format
+DATE_TAG=$(date +%Y/%m)
+
+# Replace slashes with dashes for Docker tag compatibility
+DATE_TAG=$(echo $DATE_TAG | tr '/' '-')
+
+# Execute download.sh
+echo "Executing download.sh..."
+bash $script_dir/download.sh
+
+# Check if download.sh executed successfully
+if [ $? -ne 0 ]; then
+  echo "download.sh execution failed. Exiting."
+  exit 1
+fi
+
+# Based nvidia/cuda:12.5.0-devel-ubuntu22.04
+BASE_NAME="nvidia/cuda:12.5.0-devel-ubuntu22.04"
+# Build Docker image with the date tag
+echo "Building Docker image on ${BASE_NAME} with tag ${DATE_TAG}..."
+docker build -t cuda-lustre-mpich:${DATE_TAG} -f buildcudalustrempich.dockerfile --build-arg DATE_TAG=${DATE_TAG} .
+
+# Check if Docker build was successful
+if [ $? -ne 0 ]; then
+  echo "Docker build failed. Exiting."
+  exit 1
+fi
+
+echo "Docker image built successfully with tag ${DATE_TAG}."

--- a/cuda/cuda-lustre-mpich/buildcudalustrempich.dockerfile
+++ b/cuda/cuda-lustre-mpich/buildcudalustrempich.dockerfile
@@ -1,0 +1,197 @@
+# This recipe supports multi-stage builds
+# This recepe includes CUDA 12.5.0 / lustre-aware MPICH 3.4.3 / Lustre 2.15.63 / OSU 6.2
+
+ARG OS_VERSION="22.04"
+FROM nvidia/cuda:12.5.0-devel-ubuntu22.04 as builder
+# redefine after FROM to ensure it is defined
+ARG OS_VERSION="22.04"
+# mpich version
+ARG MPICH_VERSION="3.4.3"
+# lustre version
+ARG LUSTRE_VERSION="2.15.63"
+# mpi4py version
+ARG MPI4PY_VERSION="3.1.4"
+# OSU version
+ARG OSU_VERSION="6.2"
+
+ARG DATE_TAG="2024-06"
+
+#define some metadata 
+LABEL org.opencontainers.image.created="2024-06"
+LABEL org.opencontainers.image.authors="Shusen Liu <shusen.liu@pawsey.org.au>"
+LABEL org.opencontainers.image.documentation="https://github.com/PawseySC/pawsey-containers/"
+LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers/cuda/cuda-lustre-mpich/buildlustrempich.dockerfile"
+LABEL org.opencontainers.image.vendor="Pawsey Supercomputing Research Centre"
+LABEL org.opencontainers.image.licenses="GNU GPL3.0"
+LABEL org.opencontainers.image.title="Setonix compatible Lustre-aware MPICH with CUDA 12.5"
+LABEL org.opencontainers.image.description="Common base image providing lustre-aware mpi compatible with cray-mpich, lustre and CUDA used on Setonix"
+LABEL org.opencontainers.image.base.name="pawsey/cuda-lustre-mpich:${DATE_TAG}.cuda.setonix"
+
+# syntax=docker/dockerfile:1 
+
+#COPY ./kernel-docker/kernel-headers.tar /tmp/kernel-docker/  
+# Install kernel headers
+# RUN echo "Installing kernel headers" \
+#     && cd /tmp/kernel-docker \
+#     && tar xf kernel-headers.tar\
+#     && tar xf kernel-dev.tar \
+#     && cp -r usr/include/* /usr/include/ \
+#     && cp -r usr/src/* /usr/src/ \
+#     && rm -rf /tmp/kernel-docker \
+#     && cd / \
+#     && echo "Finished installing kernel"
+
+
+
+# run apt-get install on a few packages
+ENV DEBIAN_FRONTEND="noninteractive"
+RUN apt-get update -qq \
+    && apt-get -y --no-install-recommends install \
+        build-essential \
+        ca-certificates \
+        gdb \
+        gcc g++ gfortran \
+        wget \
+        git \
+        python3-six python3-setuptools \
+        patchelf strace ltrace \
+        libcrypt-dev \ 
+        libcurl4-openssl-dev \
+        libpython3-dev \
+        libreadline-dev \
+        libssl-dev \
+        sudo \
+        autoconf \
+        automake \
+        bison \
+        curl \
+        flex \
+        gcovr \
+        gdb \
+        libtool \
+        m4 \
+        make \
+        openssh-server \
+        patch \
+        python3-numpy \
+        python3-pip \
+        python3-scipy \
+        subversion \
+        tzdata \
+        valgrind \
+        vim \
+        wget \
+        xsltproc \
+        zlib1g-dev \
+        libkeyutils-dev libnl-genl-3-dev libyaml-dev linux-headers-$(uname -r) \
+        libmount-dev pkg-config \
+    && apt-get clean all \
+    && rm -r /var/lib/apt/lists/* \
+    && echo "Finished apt-get installs"
+
+#Copy lustre, mpich and OSU to image
+ADD downloaded_files.tar.gz /tmp/
+
+# Build lustre
+RUN echo "Building lustre" \
+    && cd /tmp/lustre-build/lustre-release \
+    && chmod +x ./autogen.sh && ./autogen.sh \
+    && ./configure --disable-server --enable-client \
+    && make -j8 \
+    && cd /tmp/lustre-build/lustre-release \
+    && make install \
+    && echo "Finished building lustre"
+
+
+# Build MPICH
+ARG MPICH_CONFIGURE_OPTIONS="--without-mpe --enable-fortran=all --enable-shared --enable-sharedlibs=gcc --enable-debuginfo --enable-yield=sched_yield \
+--enable-g=mem --with-device=ch4:ofi --with-namepublisher=file \
+--with-shared-memory=sysv \
+--disable-allowport \
+--with-pm=gforker \
+--with-file-system=ufs+lustre+nfs \
+--enable-threads=runtime \
+--enable-fast=O2 \
+--enable-thread-cs=global \
+"
+ARG MPICH_MAKE_OPTIONS="-j8"
+
+RUN echo "Building MPICH ... " \
+    && cd /tmp/mpich-build/mpich-${MPICH_VERSION}   \
+    &&./configure ${MPICH_CONFIGURE_OPTIONS} FFLAGS=-fallow-argument-mismatch \
+    && make ${MPICH_MAKE_OPTIONS} \
+    && echo "Finished building MPICH" 
+
+FROM nvidia/cuda:12.5.0-devel-ubuntu22.04 as prod
+# redefine after FROM to ensure it is defined
+ARG OS_VERSION="22.04"
+# mpich version
+ARG MPICH_VERSION="3.4.3"
+# lustre version
+ARG LUSTRE_VERSION="2.15.63"
+# mpi4py version
+ARG MPI4PY_VERSION="3.1.4"
+# OSU version
+ARG OSU_VERSION="6.2"
+
+RUN apt-get update -qq \
+    && apt-get -y --no-install-recommends install \
+    libreadline-dev \
+    libmount-dev pkg-config \
+    zlib1g-dev\
+    libcrypt-dev \ 
+    libcurl4-openssl-dev \
+    libpython3-dev \
+    libreadline-dev \
+    libssl-dev \
+    valgrind \
+    gfortran\
+    libkeyutils-dev libnl-genl-3-dev libyaml-dev linux-headers-$(uname -r) \
+    && apt-get clean all \
+    && rm -r /var/lib/apt/lists/* \
+    && echo "Finished apt-get installs"
+
+WORKDIR /tmp/
+
+COPY --from=builder /tmp/ /tmp/
+
+# install lustre from stage builder
+RUN cd /tmp/lustre-build/lustre-release \
+    && make install \
+    && echo "Finished installing lustre"
+
+# install mpich from stage builder
+RUN cd /tmp/mpich-build/mpich-${MPICH_VERSION} \
+    && make install \
+    && ldconfig \
+    && cp -p /tmp/mpich-build/mpich-${MPICH_VERSION}/examples/cpi /usr/bin/ \
+    && echo "Finished installing MPICH"
+
+# Build and install OSU Benchmarks
+ARG OSU_CONFIGURE_OPTIONS="--prefix=/usr/local CC=mpicc CXX=mpicxx CFLAGS=-O3"
+ARG OSU_MAKE_OPTIONS="-j8"
+RUN echo "Building and installing OSU..." \
+    && cd /tmp/osu-benchmarks-build/osu-micro-benchmarks-${OSU_VERSION} \
+    && ./configure ${OSU_CONFIGURE_OPTIONS} \
+    && make ${OSU_MAKE_OPTIONS} \
+    && make install \
+    && echo "Finished building and installing OSU"
+
+
+ENV PATH="/usr/local/libexec/osu-micro-benchmarks/mpi/collective:/usr/local/libexec/osu-micro-benchmarks/mpi/one-sided:/usr/local/libexec/osu-micro-benchmarks/mpi/pt2pt:/usr/local/libexec/osu-micro-benchmarks/mpi/startup:$PATH"
+
+
+
+#clean /tmp
+RUN rm -rf /tmp/*
+# add mpi4py in the container 
+#RUN pip install mpi4py==${MPI4PY_VERSION}
+
+RUN mkdir -p /container-scratch/
+
+# and copy the recipe into the docker recipes directory
+RUN mkdir -p /opt/docker-recipes/
+COPY buildcudalustrempich.dockerfile /opt/docker-recipes/
+
+# Final
+CMD ["/bin/bash"]   

--- a/cuda/cuda-lustre-mpich/download.sh
+++ b/cuda/cuda-lustre-mpich/download.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# lustre version  2.15.63  or main
+LUSTRE_VERSION="2.15.63"
+# mpich version
+MPICH_VERSION="3.4.3"
+# osu version
+OSU_VERSION="6.2"
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+echo "Downloading lustre source"
+
+if [ -d "$script_dir/lustre-build" ]; then
+    echo "Removing existing lustre-build directory"
+    rm -rf $script_dir/lustre-build
+fi
+
+mkdir -p $script_dir/lustre-build
+cd $script_dir/lustre-build
+git clone git://git.whamcloud.com/fs/lustre-release.git
+cd lustre-release
+# Fetch tags and checkout the specified version
+git fetch --tags && git checkout ${LUSTRE_VERSION}
+echo "Finished downloading and checking out lustre source"
+
+echo "Downloading MPICH"
+if [ -d "$script_dir/mpich-build" ]; then
+    echo "Removing existing mpich-build directory"
+    rm -rf $script_dir/mpich-build
+fi
+mkdir -p $script_dir/mpich-build/
+wget -P $script_dir/mpich-build/ http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
+tar xf $script_dir/mpich-build/mpich-${MPICH_VERSION}.tar.gz -C $script_dir/mpich-build/
+rm -f $script_dir/mpich-build/mpich-${MPICH_VERSION}.tar.gz
+cp $script_dir/mpich_patches.tgz $script_dir/mpich-build/mpich-${MPICH_VERSION}
+cd $script_dir/mpich-build/mpich-${MPICH_VERSION}
+tar xf mpich_patches.tgz
+patch -p0 < csel.patch
+patch -p0 < ch4r_init.patch
+rm $script_dir/mpich-build/mpich-${MPICH_VERSION}/mpich_patches.tgz
+echo "MPICH has been downloaded and patched"
+
+echo "Downloading OSU Benchmarks"
+if [ -d "$script_dir/osu-benchmarks" ]; then
+    echo "Removing existing osu-benchmarks directory"
+    rm -rf $script_dir/osu-benchmarks
+fi
+mkdir -p $script_dir/osu-benchmarks-build
+cd $script_dir/osu-benchmarks-build
+wget https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-${OSU_VERSION}.tar.gz -O osu-micro-benchmarks-${OSU_VERSION}.tar.gz
+tar xzvf osu-micro-benchmarks-${OSU_VERSION}.tar.gz
+rm -f osu-micro-benchmarks-${OSU_VERSION}.tar.gz
+echo "Finished downloading OSU Benchmarks"
+
+# package all downloaded files for transferring to docker image
+cd $script_dir
+tar czvf downloaded_files.tar.gz lustre-build mpich-build osu-benchmarks-build
+echo "All files have been packaged into downloaded_files.tar.gz"
+
+# del them
+rm -rf lustre-build mpich-build osu-benchmarks-build
+echo "All source directories have been removed"

--- a/python/hpc-python/requirements-12-2023.txt
+++ b/python/hpc-python/requirements-12-2023.txt
@@ -12,7 +12,7 @@ asttokens==2.4.1
     # via stack-data
 bokeh==3.3.2
     # via dask
-certifi==2023.11.17
+certifi==2024.7.4
     # via netcdf4
 cftime==1.6.3
     # via netcdf4
@@ -60,7 +60,7 @@ ipython==8.18.1
     # via -r /opt/tmp/requirements.in
 jedi==0.19.1
     # via ipython
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   bokeh
     #   dask
@@ -131,7 +131,7 @@ partd==1.4.1
     # via dask
 pexpect==4.9.0
     # via ipython
-pillow==10.1.0
+pillow==10.3.0
     # via
     #   bokeh
     #   matplotlib
@@ -171,7 +171,7 @@ pyyaml==6.0.1
     #   bokeh
     #   dask
     #   distributed
-scikit-learn==1.3.2
+scikit-learn==1.5.0
     # via -r /opt/tmp/requirements.in
 scipy==1.11.4
     # via
@@ -196,7 +196,7 @@ toolz==0.12.0
     #   dask
     #   distributed
     #   partd
-tornado==6.4
+tornado==6.4.1
     # via
     #   bokeh
     #   distributed
@@ -206,7 +206,7 @@ traitlets==5.14.0
     #   matplotlib-inline
 tzdata==2023.3
     # via pandas
-urllib3==2.1.0
+urllib3==2.2.2
     # via distributed
 wcwidth==0.2.12
     # via prompt-toolkit
@@ -214,5 +214,5 @@ xyzservices==2023.10.1
     # via bokeh
 zict==3.0.0
     # via distributed
-zipp==3.17.0
+zipp==3.19.1
     # via importlib-metadata


### PR DESCRIPTION
* Bump pillow from 10.1.0 to 10.3.0 in /python/hpc-python

Bumps [pillow](https://github.com/python-pillow/Pillow) from 10.1.0 to 10.3.0.
- [Release notes](https://github.com/python-pillow/Pillow/releases)
- [Changelog](https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst)
- [Commits](https://github.com/python-pillow/Pillow/compare/10.1.0...10.3.0)

---
updated-dependencies:
- dependency-name: pillow dependency-type: direct:production ...



* Bump jinja2 from 3.1.2 to 3.1.4 in /python/hpc-python

Bumps [jinja2](https://github.com/pallets/jinja) from 3.1.2 to 3.1.4.
- [Release notes](https://github.com/pallets/jinja/releases)
- [Changelog](https://github.com/pallets/jinja/blob/main/CHANGES.rst)
- [Commits](https://github.com/pallets/jinja/compare/3.1.2...3.1.4)

---
updated-dependencies:
- dependency-name: jinja2 dependency-type: direct:production ...



* Bump tornado from 6.4 to 6.4.1 in /python/hpc-python

Bumps [tornado](https://github.com/tornadoweb/tornado) from 6.4 to 6.4.1.
- [Changelog](https://github.com/tornadoweb/tornado/blob/master/docs/releases.rst)
- [Commits](https://github.com/tornadoweb/tornado/compare/v6.4.0...v6.4.1)

---
updated-dependencies:
- dependency-name: tornado dependency-type: direct:production ...



* Bump urllib3 from 2.1.0 to 2.2.2 in /python/hpc-python

Bumps [urllib3](https://github.com/urllib3/urllib3) from 2.1.0 to 2.2.2.
- [Release notes](https://github.com/urllib3/urllib3/releases)
- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)
- [Commits](https://github.com/urllib3/urllib3/compare/2.1.0...2.2.2)

---
updated-dependencies:
- dependency-name: urllib3 dependency-type: direct:production ...



* Bump scikit-learn from 1.3.2 to 1.5.0 in /python/hpc-python

Bumps [scikit-learn](https://github.com/scikit-learn/scikit-learn) from 1.3.2 to 1.5.0.
- [Release notes](https://github.com/scikit-learn/scikit-learn/releases)
- [Commits](https://github.com/scikit-learn/scikit-learn/compare/1.3.2...1.5.0)

---
updated-dependencies:
- dependency-name: scikit-learn dependency-type: direct:production ...



* Update the logic of scripts. DATE_TAG will be used as image tag for image.

* Del duplicated script for qiskit under python/hpc-python. Move and extend to application folder.

* Bump zipp from 3.17.0 to 3.19.1 in /python/hpc-python

Bumps [zipp](https://github.com/jaraco/zipp) from 3.17.0 to 3.19.1.
- [Release notes](https://github.com/jaraco/zipp/releases)
- [Changelog](https://github.com/jaraco/zipp/blob/main/NEWS.rst)
- [Commits](https://github.com/jaraco/zipp/compare/v3.17.0...v3.19.1)

---
updated-dependencies:
- dependency-name: zipp dependency-type: direct:production ...



* Bump certifi from 2023.11.17 to 2024.7.4 in /python/hpc-python

Bumps [certifi](https://github.com/certifi/python-certifi) from 2023.11.17 to 2024.7.4.
- [Commits](https://github.com/certifi/python-certifi/compare/2023.11.17...2024.07.04)

---
updated-dependencies:
- dependency-name: certifi dependency-type: direct:production ...



* A Qiskit-aer-GPU (v0.15) built with a minimal image based on CUDA 12.5, compatible with Grace Hopper, and supporting aarch64 architectures. No MPI and Lustre supported.

---------