### PR TITLE
update mpich-base dockerfile to build from ubuntu24.04

### DIFF
--- a/mpi/mpich-base/buildmpich.dockerfile
+++ b/mpi/mpich-base/buildmpich.dockerfile
@@ -11,8 +11,8 @@ ARG OS_VERSION="24.04"
 ARG MPICH_VERSION="3.4.3"
 
 #define some metadata 
-LABEL org.opencontainers.image.created="2023-02"
-LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>"
+LABEL org.opencontainers.image.created="2025-06"
+LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au"
 LABEL org.opencontainers.image.documentation="https://github.com/PawseySC/pawsey-containers/"
 LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers/mpi/mpich-base/buildmpich.dockerfile"
 LABEL org.opencontainers.image.vendor="Pawsey Supercomputing Research Centre"

--- a/mpi/mpich-base/buildmpich.dockerfile
+++ b/mpi/mpich-base/buildmpich.dockerfile
@@ -3,10 +3,10 @@
 # builds mpich and also some useful mpi packages for testing
 # The labels present here will need to be updated
 
-ARG OS_VERSION="20.04"
+ARG OS_VERSION="24.04"
 FROM ubuntu:${OS_VERSION}
 # redefine after FROM to ensure it is defined
-ARG OS_VERSION="20.04"
+ARG OS_VERSION="24.04"
 # mpich version
 ARG MPICH_VERSION="3.4.3"
 
@@ -67,7 +67,7 @@ RUN apt-get update -qq \
     && echo "Finished apt-get installs"
 
 # Build MPICH
-ARG MPICH_CONFIGURE_OPTIONS="--enable-fast=all,O3 --enable-fortran --enable-romio --prefix=/usr --with-device=ch4:ofi CC=gcc CXX=g++ FC=gfortran"
+ARG MPICH_CONFIGURE_OPTIONS="--enable-fast=all,O3 --enable-fortran --enable-romio --prefix=/usr --with-device=ch4:ofi CC=gcc CXX=g++ FC=gfortran FFLAGS=-fallow-argument-mismatch FCFLAGS=-fallow-argument-mismatch"
 ARG MPICH_MAKE_OPTIONS="-j4"
 RUN mkdir -p /tmp/mpich-build \
       && cd /tmp/mpich-build \
@@ -97,21 +97,10 @@ RUN mkdir -p /tmp/osu-benchmark-build \
       && rm -rf /tmp/osu-benchmark-build
 ENV PATH="/usr/local/libexec/osu-micro-benchmarks/mpi/collective:/usr/local/libexec/osu-micro-benchmarks/mpi/one-sided:/usr/local/libexec/osu-micro-benchmarks/mpi/pt2pt:/usr/local/libexec/osu-micro-benchmarks/mpi/startup:$PATH"
 
-# Add a more complex set of tests for MPI as well 
-RUN mkdir -p /opt/ \
-      && cd /opt/ \
-      && git clone https://github.com/pelahi/profile_util \
-      && cd profile_util  \
-      && sed -i "s:CXX=CC:CXX=g++:g" ./build_cpu.sh \
-      && sed -i "s:MPICXX=CC:MPICXX=mpic++:g" ./build_cpu.sh \
-      && ./build_cpu.sh \
-      && cd examples/mpi/ \
-      && make MPICXX=mpic++ \
-      && cd ../../examples/openmp \
-      && make CXX=g++ bin/openmpvec_cpp
 
 # add mpi4py in the container 
-RUN pip install mpi4py
+# CMEYER: --breaks-system-packages needed with python/3.12 + ubuntu24.04
+RUN pip install --break-system-packages mpi4py
 
 RUN mkdir -p /container-scratch/
 

--- a/mpi/mpich-base/buildmpich.dockerfile
+++ b/mpi/mpich-base/buildmpich.dockerfile
@@ -97,6 +97,19 @@ RUN mkdir -p /tmp/osu-benchmark-build \
       && rm -rf /tmp/osu-benchmark-build
 ENV PATH="/usr/local/libexec/osu-micro-benchmarks/mpi/collective:/usr/local/libexec/osu-micro-benchmarks/mpi/one-sided:/usr/local/libexec/osu-micro-benchmarks/mpi/pt2pt:/usr/local/libexec/osu-micro-benchmarks/mpi/startup:$PATH"
 
+# Add a more complex set of tests for MPI as well
+RUN mkdir -p /opt/ \
+      && cd /opt/ \
+      && git clone https://github.com/pelahi/profile_util \
+      && cd profile_util  \
+      && sed -i "s:CXX=CC:CXX=g++:g" ./build_cpu.sh \
+      && sed -i "s:MPICXX=CC:MPICXX=mpic++:g" ./build_cpu.sh \
+      && ./build_cpu.sh \
+      && cd examples/mpi/ \
+      && make MPICXX=mpic++ \
+      && cd ../../examples/openmp \
+      && make CXX=g++ bin/openmpvec_cpp
+
 
 # add mpi4py in the container 
 # CMEYER: --breaks-system-packages needed with python/3.12 + ubuntu24.04


### PR DESCRIPTION
This uupdates the mpich-base dockerfile to build from ubuntu24.04. An mpich-base:3.4.3 base image has been built using this updated dockerfile, and tested with several different MPI test cases.