### PR TITLE
Update to rocm-mpich-base dockerfile for ubuntu24.04

### DIFF
--- a/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
+++ b/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
@@ -15,8 +15,8 @@ ARG MPI4PY_VERSION="3.1.5"
 
 
 #define some metadata 
-LABEL org.opencontainers.image.created="2024-02"
-LABEL org.opencontainers.image.authors="Cristian Di Pietratonio <cristian.dipietrantonio@pawsey.org.au>, Pascal Elahi <pascal.elahi@pawsey.org.au>"
+LABEL org.opencontainers.image.created="2025-06"
+LABEL org.opencontainers.image.authors="Cristian Di Pietratonio <cristian.dipietrantonio@pawsey.org.au>, Pascal Elahi <pascal.elahi@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>"
 LABEL org.opencontainers.image.documentation="https://github.com/PawseySC/pawsey-containers/"
 LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers/mpi/mpich-base/buildmpich.dockerfile"
 LABEL org.opencontainers.image.vendor="Pawsey Supercomputing Research Centre"

--- a/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
+++ b/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
@@ -208,12 +208,9 @@ RUN echo "Building rocm ${ROCM_VERSION}" \
     && echo ${roc_url} \
     && wget ${roc_url} \
     && apt -y install ./amdgpu-install_${ROCM_INSTALLER_VERSION}_all.deb \
-    # CMEYER: older rocm versions not installing when --no-dkms not used - may be incompatibility with older rocm + newer OS
-    && if [ "$rocm_major" -lt 6 ] || { [ "$rocm_major" -eq 6 ] && [ "$rocm_minor" -lt 2 ]; }; then \
-        amdgpu-install -y --usecase=hiplibsdk,rocm,hip,opencl --no-dkms; \
-       else \
-        amdgpu-install -y --usecase=hiplibsdk,rocm,hip,opencl; \
-       fi \
+    # CMEYER: Adding --no-dkms - older rocm versions fail without it and seems to be recommended by amd
+    # CMEYER: See https://rocmdocs.amd.com/projects/install-on-linux/en/latest/install/install-methods/amdgpu-installer/amdgpu-installer-ubuntu.html and https://github.com/amd/InfinityHub-CI/blob/55ffdd622595cf678fb55fce7681792390173f3d/base-mpich-rocm-docker/Dockerfile#L47
+    && amdgpu-install -y --usecase=hiplibsdk,rocm,hip,opencl --no-dkms \
     && cd /tmp/build && rm -rf amdgpu-install_${ROCM_INSTALLER_VERSION}_all.deb \
     && echo "Done"
 

--- a/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
+++ b/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
@@ -10,7 +10,8 @@ ARG MPICH_VERSION="3.4.3"
 # lustre version
 ARG LUSTRE_VERSION="2.15.0-RC4"
 # mpi4py version
-ARG MPI4PY_VERSION="3.1.4"
+# CMEYER: 3.1.4 fails to install in ubuntu24.04, minimal upgrade to 3.1.5 does sinstall
+ARG MPI4PY_VERSION="3.1.5"
 
 
 #define some metadata 
@@ -171,8 +172,7 @@ RUN echo "Building MPICH ... " \
     && echo "Finished building MPICH" 
 
 # add mpi4py in the container
-# CMEYER: Version 3.4.1 not installing smoothly in ubuntu24.04, default version 4.1.0 installs
-RUN pip install --break-system-packages mpi4py
+RUN pip install --break-system-packages mpi4py==${MPI4PY_VERSION}
 RUN apt -y update
 RUN apt -y upgrade
 RUN apt -y install rsync

--- a/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
+++ b/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
@@ -260,34 +260,22 @@ ENV PATH="/usr/local/libexec/osu-micro-benchmarks/mpi/collective:/usr/local/libe
 
 # For the moment, not adding the more complex mpi tests as this can be added later
 # Add a more complex set of tests for MPI as well 
-RUN echo "Adding some extra mpi tests " \
-    && mkdir -p /opt/ \
-    && cd /opt/ \
-    && git clone https://github.com/pelahi/profile_util \
-    && cd profile_util  \
-    # CMEYER: Edits needed for ./build_cpu.sh and ./build_hip.sh configured for cray/ella systems
-    && sed -i "s:CXX=CC:CXX=g++:g" ./build_cpu.sh \
-    && sed -i "s:MPICXX=CC:MPICXX=mpic++:g" ./build_cpu.sh \
-    && sed -i "s:MPICXX=CC:MPICXX=mpic++:g" ./build_hip.sh \
-    && sed -i -E 's|^CXX="hipcc --amdgpu-target=gfx90a.*"|CXX="hipcc --amdgpu-target=gfx90a -stdlib++-isystem /usr/include/c++/11 -stdlib++-isystem /usr/include/x86_64-linux-gnu/c++/11"|' ./build_hip.sh \
-    && sed -i -E 's|^MPICXX="hipcc --amdgpu-target=gfx90a.*"|MPICXX="hipcc --amdgpu-target=gfx90a -stdlib++-isystem /usr/include/c++/11 -stdlib++-isystem /usr/include/x86_64-linux-gnu/c++/11"|' ./build_hip.sh \
-    && sed -i -E 's|^(GPUFLAGS="[^"]*)|\1 -I/opt/rocm/include|' ./build_hip.sh \
-    && ./build_cpu.sh \
-    && ./build_hip.sh \
-    && cd examples/mpi/ \
-    && make MPICXX=mpic++ \
-    && cd ../../examples/openmp \
-    && make CXX=g++ bin/openmpvec_cpp \
-    && cd ../../examples/gpu-openmp \
-    # CMEYER: Add rocm/path for building gpu-openmp tests
-    && sed -i -E 's|^(GPUFLAGS=.*)|\1 -I/opt/rocm/include|' Makefile \
-    && cd ../../examples/gpu-mpi/ \
-    # CMEYER: Edits for gpu-mpi tests
-    && sed -i -E 's|^(GPUFLAGS=.*)|\1 -I/opt/rocm/include|' Makefile \
-    && sed -i -E 's|\$\(cXXFLAGS\)|$(CXXFLAGS)|g' Makefile \
-    && sed -i 's|-fopenmp-targets=amdgcn-amd-amdhsa||g' Makefile \
-    && make CXX=hipcc GPU=hip MPICXX=hipcc ARCH=gfx90a CRAY=false CXXFLAGS="-I/usr/local/include -L/usr/local/lib" \
-    && echo "Done"
+# RUN echo "Adding some extra mpi tests " \
+#     && mkdir -p /opt/ \
+#     && cd /opt/ \
+#     && git clone https://github.com/pelahi/profile_util \
+#     && cd profile_util  \
+#     && sed -i "s:CXX=CC:CXX=g++:g" ./build_cpu.sh \
+#     && sed -i "s:MPICXX=CC:MPICXX=mpic++:g" ./build_cpu.sh \
+#     && sed -i "s:MPICXX=CC:MPICXX=mpic++:g" ./build_hip.sh \
+#     && ./build_hip.sh \
+#     && cd examples/mpi/ \
+#     && make MPICXX=mpic++ \
+#     && cd ../../examples/openmp \
+#     && make CXX=g++ bin/openmpvec_cpp \
+#     && cd ../../examples/gpu-mpi/ \
+#     && make \
+#     && echo "Done"
 
 # Set some environment variables related to gpu communication and libfabric
 ENV NCCL_SOCKET_IFNAME=hsn


### PR DESCRIPTION
The updates made to the dockerfile to facilitate building with ubuntu/24.04 base image are:

- Changing the base ubuntu image version
- Updating mpi4py from `mpi4py/3.1.4` to `mpi4py/3.1.5`
- Use newer linux kernel to reflect newer OS
- Updates to how `./debian/scripts/misc/annotations` is accessed in ubuntu/24.04
- Conditional logic to allow this dockerfile to be used for both rocm/5.x and rocm/6.x installations. `rocm/5.x` need jammy repo sources to be able to install required libraries and amd install URLs point to noble for `rocm/6.2.x` and later, compared to jammy for earlier versions
- `--no-dkms` option added to `amdgpu-install` command. Needed for earlier rocm versions (5.x) to install, used by AMD in their own documentation and dockerfiles