### PR TITLE
Updates to dockerfiles for openfoam-org:7,8,9

### DIFF
--- a/OpenFOAM/openfoam-org/7/Dockerfile
+++ b/OpenFOAM/openfoam-org/7/Dockerfile
@@ -234,7 +234,8 @@ RUN . ${OFBASHRC} \
  && cd ${WM_PROJECT_DIR}
 WORKDIR /opt/OpenFOAM/OpenFOAM-7
 COPY sha1-fix.patch /tmp/sha1-fix.patch
-RUN patch -p1 < /tmp/sha1-fix.patch
+RUN patch -p1 < /tmp/sha1-fix.patch \
+ && rm /tmp/sha1-fix.patch
 
 # CMEYER: Install cgal from source, given library packaged with ubuntu/24.04 incompatible with openfoam 7
 RUN apt-get update -qq\

--- a/OpenFOAM/openfoam-org/7/Dockerfile
+++ b/OpenFOAM/openfoam-org/7/Dockerfile
@@ -4,8 +4,8 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # IMPORTANT: 
-# Setonix needs at least ubuntu20.04 (From August 2023)
-FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
+# Setonix needs at least ubuntu24.04 (From August 2025)
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu24.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install
@@ -43,8 +43,8 @@ RUN echo "root:${OFVERSION}" | chpasswd
 #Recent native developers' containers are not using this "ofuser" anymore, although it is still useful to have it
 #for pawsey purposes where /group needs to be used as the place for the *USER* variables. Then, /group directory
 #will be mounted into the ofuser dir whenever own compiled tools are used
-RUN groupadd -g 999 ofuser \
- && useradd -r -m -u 999 -g ofuser ofuser
+RUN groupadd -g 10001 ofuser \
+ && useradd -r -m -u 10001 -g ofuser ofuser
 RUN echo "ofuser:${OFVERSION}" | chpasswd
 
 
@@ -87,20 +87,24 @@ RUN apt-get update -qq\
 #AEG:NoOpenMPI:   libopenmpi-dev openmpi-bin \
    gnuplot libreadline-dev libncurses-dev \
 #AEG:NoQt4: libqtwebkit-dev \ 
-   libqt5x11extras5-dev libxt-dev qt5-default qttools5-dev curl \
+#AEG: CMEYER suggestion:replace qt5-default by the expanded set of qt5 libraries for ubuntu24.04
+    #qt5-default \
+    qtbase5-dev qttools5-dev qttools5-dev-tools qtchooser qt5-qmake qtbase5-dev-tools libqt5opengl5-dev libqt5x11extras5-dev libxt-dev \
+    curl \
 #--continue
    freeglut3-dev \
 #AEG:No scotch because it installs openmpi which later messes up with MPICH
 #    Therefore, ThirdParty scotch is the one to be installed and used by openfoam.
 #AEG:NoScotch:   libscotch-dev \
 #AEG:(No third party CGAL is provided (although can be downloaded) but will use the system installation):
-   libcgal-dev \
+#CMEYER: ubuntu/24.04 libcgal-dev incompatible with openfoam 7, build cgal from source instead
+   #libcgal-dev \
 #AEG:These libraries are needed for CGAL (system and third party) (if needed, change libgmp-dev for libgmp3-dev):
    libgmp-dev libmpfr-dev\
 #AEG:Wiki additional qt suggestions:
    qtbase5-dev \
 #AEG: Some more suggestions from the wiki instructions:
-   python python-dev \
+   python3 python3-dev \
    libglu1-mesa-dev \
 #AEG:I found the following was needed to install  FlexLexer.hi (now included in the wiki instructions too):
    libfl-dev \
@@ -193,17 +197,21 @@ ARG BASHRC_OPTIONS="FOAMY_HEX_MESH=yes"
 
 #AEG: foundation source files do not count with makeVTK script, so will not attempt to install VTK
 
+# CMEYER: Paraview is failing to build in ubuntu24.04 with default Python and Compiler. So Paraview (or paraFoam) will not work inside this container. 
+# If there is still interest to compile it, the recommendation is to try installing an old verion of Python and gcc and attempt compilation again or else
+# upgrade to ParaView/6.0.0, which compiles fine with default python and compilers in container, but may have runtime issues with older openfoam 
+# due to how comparatively new it is
 ##Paraview compilation (Using instructions from the wiki)
-RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
- && cd $WM_THIRD_PARTY_DIR \
- && export QT_SELECT=qt5 \
-#downloading ParaView with wget because the supposedly automatic download with curl is failing
-#(Paraview download address pasted from ThirdParty-<Version>/README.org)
- && wget --no-check-certificate http://www.paraview.org/files/v5.6/ParaView-v5.6.0.tar.gz \
- && tar xvf ParaView-v5.6.0.tar.gz \
- && rm ParaView-v5.6.0.tar.gz \
- && mv ParaView-v5.6.0 ParaView-5.6.0 \
- && ./makeParaView -python -mpi -python-lib /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0 2>&1 | tee log.makePV
+# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#  && cd $WM_THIRD_PARTY_DIR \
+#  && export QT_SELECT=qt5 \
+# #downloading ParaView with wget because the supposedly automatic download with curl is failing
+# #(Paraview download address pasted from ThirdParty-<Version>/README.org)
+#  && wget --no-check-certificate http://www.paraview.org/files/v5.6/ParaView-v5.6.0.tar.gz \
+#  && tar xvf ParaView-v5.6.0.tar.gz \
+#  && rm ParaView-v5.6.0.tar.gz \
+#  && mv ParaView-v5.6.0 ParaView-5.6.0 \
+#  && ./makeParaView -python -mpi -python-include /usr/local/include/python2.7 -python-lib /usr/local/lib/libpython2.7.so.1.0 2>&1 | tee log.makePV
 
 #...........
 #Step 5.
@@ -219,6 +227,38 @@ RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
 #@@-@@#:#--Dummy line:
 #@@-@@#: && echo ''
 
+#CMEYER: Patch files for fix to sha1 overload problem
+#CMEYER: see https://develop.openfoam.com/Development/openfoam/-/issues/2496
+#CMEYER: see https://develop.openfoam.com/Development/openfoam/-/commit/eb3f7dfe7443fe852b256072f337ac24effff0ac
+RUN . ${OFBASHRC} \
+ && cd ${WM_PROJECT_DIR}
+WORKDIR /opt/OpenFOAM/OpenFOAM-7
+COPY sha1-fix.patch /tmp/sha1-fix.patch
+RUN patch -p1 < /tmp/sha1-fix.patch
+
+# CMEYER: Install cgal from source, given library packaged with ubuntu/24.04 incompatible with openfoam 7
+RUN apt-get update -qq\
+ && apt-get -y --no-install-recommends install \
+   build-essential cmake libboost-all-dev libgmp-dev libmpfr-dev
+RUN mkdir -p /tmp/cgal-build \
+ && cd /tmp/cgal-build \
+ && wget https://github.com/CGAL/cgal/releases/download/releases/CGAL-4.10/CGAL-4.10.tar.xz \
+ && tar -xf CGAL-4.10.tar.xz \
+ && cd CGAL-4.10 \
+ && mkdir build \
+ && cd build \
+ && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local/cgal-4.10 \
+ && make -j 4 \
+ && make install \
+ && cd /tmp \
+ && rm -rf CGAL-4.10 CGAL-4.10.tar.xz
+
+ENV CGAL_INC_DIR=/usr/local/cgal-4.10/include \
+   CGAL_LIB_DIR=/usr/local/cgal-4.10/lib \
+   LD_LIBRARY_PATH=$CGAL_LIB_DIR:$LD_LIBRARY_PATH \
+   CPATH=$CGAL_INC_DIR:$CPATH \
+   LIBRARY_PATH=$CGAL_LIB_DIR:$LIBRARY_PATH
+
 #Third party compilation
 RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
  && cd $WM_THIRD_PARTY_DIR \
@@ -230,6 +270,9 @@ RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
 ARG OFNUMPROCOPTION="-j 4"
 RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
  && cd $WM_PROJECT_DIR \
+ # CMEYER: Patch etc/config/CGAL.sh to use custom-installed cgal
+ && sed -i 's/^cgal_version=cgal-system$/cgal_version=CGAL-4.10/' ./etc/config.sh/CGAL \
+ && echo -e "\nif [ \"\$cgal_version\" != \"cgal-system\" ]\nthen\n    export CGAL_ARCH_PATH=/usr/local/cgal-4.10\nfi" >> ./etc/config.sh/CGAL \
  && export QT_SELECT=qt5 \
  && ./Allwmake $OFNUMPROCOPTION 2>&1 | tee log.Allwmake
 

--- a/OpenFOAM/openfoam-org/7/Dockerfile
+++ b/OpenFOAM/openfoam-org/7/Dockerfile
@@ -201,17 +201,17 @@ ARG BASHRC_OPTIONS="FOAMY_HEX_MESH=yes"
 # If there is still interest to compile it, the recommendation is to try installing an old verion of Python and gcc and attempt compilation again or else
 # upgrade to ParaView/6.0.0, which compiles fine with default python and compilers in container, but may have runtime issues with older openfoam 
 # due to how comparatively new it is
-##Paraview compilation (Using instructions from the wiki)
-# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
-#  && cd $WM_THIRD_PARTY_DIR \
-#  && export QT_SELECT=qt5 \
-# #downloading ParaView with wget because the supposedly automatic download with curl is failing
-# #(Paraview download address pasted from ThirdParty-<Version>/README.org)
-#  && wget --no-check-certificate http://www.paraview.org/files/v5.6/ParaView-v5.6.0.tar.gz \
-#  && tar xvf ParaView-v5.6.0.tar.gz \
-#  && rm ParaView-v5.6.0.tar.gz \
-#  && mv ParaView-v5.6.0 ParaView-5.6.0 \
-#  && ./makeParaView -python -mpi -python-include /usr/local/include/python2.7 -python-lib /usr/local/lib/libpython2.7.so.1.0 2>&1 | tee log.makePV
+#NotForUb24.04##Paraview compilation (Using instructions from the wiki)
+#NotForUb24.04# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#NotForUb24.04#  && cd $WM_THIRD_PARTY_DIR \
+#NotForUb24.04#  && export QT_SELECT=qt5 \
+#NotForUb24.04# #downloading ParaView with wget because the supposedly automatic download with curl is failing
+#NotForUb24.04# #(Paraview download address pasted from ThirdParty-<Version>/README.org)
+#NotForUb24.04#  && wget --no-check-certificate http://www.paraview.org/files/v5.6/ParaView-v5.6.0.tar.gz \
+#NotForUb24.04#  && tar xvf ParaView-v5.6.0.tar.gz \
+#NotForUb24.04#  && rm ParaView-v5.6.0.tar.gz \
+#NotForUb24.04#  && mv ParaView-v5.6.0 ParaView-5.6.0 \
+#NotForUb24.04#  && ./makeParaView -python -mpi -python-lib /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0 2>&1 | tee log.makePV
 
 #...........
 #Step 5.

--- a/OpenFOAM/openfoam-org/7/sha1-fix.patch
+++ b/OpenFOAM/openfoam-org/7/sha1-fix.patch
@@ -1,0 +1,76 @@
+--- a/src/OpenFOAM/db/IOstreams/hashes/OSHA1stream.H
++++ b/src/OpenFOAM/db/IOstreams/hashes/OSHA1stream.H
+@@ -32,8 +32,8 @@
+ 
+ \*---------------------------------------------------------------------------*/
+ 
+-#ifndef OSHA1stream_H
+-#define OSHA1stream_H
++#ifndef Foam_OSHA1stream_H
++#define Foam_OSHA1stream_H
+ 
+ #include "OSstream.H"
+ #include "SHA1.H"
+@@ -62,6 +62,15 @@
+ 
+     friend class osha1stream;
+ 
++protected:
++
++    //- Handle overflow
++    virtual int overflow(int c = EOF)
++    {
++        if (c != EOF) sha1_.append(c);
++        return c;
++    }
++
+ public:
+ 
+     // Constructors
+@@ -77,7 +86,7 @@
+         //- Process unbuffered
+         virtual std::streamsize xsputn(const char* str, std::streamsize n)
+         {
+-            sha1_.append(str, n);
++            if (n) sha1_.append(str, n);
+             return n;
+         }
+ };
+--- a/src/OpenFOAM/primitives/hashes/SHA1/SHA1.H
++++ b/src/OpenFOAM/primitives/hashes/SHA1/SHA1.H
+@@ -39,8 +39,8 @@
+ 
+ \*---------------------------------------------------------------------------*/
+ 
+-#ifndef SHA1_H
+-#define SHA1_H
++#ifndef Foam_SHA1_H
++#define Foam_SHA1_H
+ 
+ #include <string>
+ #include <cstddef>
+@@ -125,6 +125,9 @@
+ 
+         //- Reset the hashed data before appending more
+         void clear();
++        
++        //- Append single character
++        inline void append(char c);
+ 
+         //- Append data for processing
+         inline SHA1& append(const char* data, size_t len);
+--- a/src/OpenFOAM/primitives/hashes/SHA1/SHA1I.H
++++ b/src/OpenFOAM/primitives/hashes/SHA1/SHA1I.H
+@@ -50,6 +50,12 @@
+ 
+ // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+ 
++inline void Foam::SHA1::append(char c)
++{
++    processBytes(&c, 1);
++}
++
++
+ inline Foam::SHA1& Foam::SHA1::append(const char* data, size_t len)
+ {
+     processBytes(data, len);

--- a/OpenFOAM/openfoam-org/8/Dockerfile
+++ b/OpenFOAM/openfoam-org/8/Dockerfile
@@ -199,7 +199,8 @@ RUN . ${OFBASHRC} \
  && cd ${WM_PROJECT_DIR}
 WORKDIR /opt/OpenFOAM/OpenFOAM-8
 COPY sha1-fix.patch /tmp/sha1-fix.patch
-RUN patch -p1 < /tmp/sha1-fix.patch
+RUN patch -p1 < /tmp/sha1-fix.patch \
+ && rm /tmp/sha1-fix.patch
 
 #Third party compilation
 RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \

--- a/OpenFOAM/openfoam-org/8/Dockerfile
+++ b/OpenFOAM/openfoam-org/8/Dockerfile
@@ -4,8 +4,8 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # IMPORTANT: 
-# Setonix needs at least ubuntu20.04 (From August 2023)
-FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
+# Setonix needs at least ubuntu24.04 (From August 2025)
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu24.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install
@@ -43,8 +43,8 @@ RUN echo "root:${OFVERSION}" | chpasswd
 #Recent native developers' containers are not using this "ofuser" anymore, although it is still useful to have it
 #for pawsey purposes where /group needs to be used as the place for the *USER* variables. Then, /group directory
 #will be mounted into the ofuser dir whenever own compiled tools are used
-RUN groupadd -g 999 ofuser \
- && useradd -r -m -u 999 -g ofuser ofuser
+RUN groupadd -g 10001 ofuser \
+ && useradd -r -m -u 10001 -g ofuser ofuser
 RUN echo "ofuser:${OFVERSION}" | chpasswd
 
 
@@ -86,7 +86,10 @@ RUN apt-get update -qq\
 #AEG:No OpenMPI because MPICH will be used (installed in the parent FROM image)
 #AEG:NoOpenMPI:   libopenmpi-dev openmpi-bin \
    gnuplot libreadline-dev libncurses-dev \
-   libqt5x11extras5-dev libxt-dev qt5-default qttools5-dev curl \
+#AEG: CMEYER suggestion:replace qt5-default by the expanded set of qt5 libraries for ubuntu24.04
+    #qt5-default \
+    qtbase5-dev qttools5-dev qttools5-dev-tools qtchooser qt5-qmake qtbase5-dev-tools libqt5opengl5-dev libqt5x11extras5-dev libxt-dev \
+    curl \
 #NotIn8:   freeglut3-dev libqtwebkit-dev \
 #AEG:No scotch because it installs openmpi which later messes up with MPICH
 #    Therefore, ThirdParty scotch is the one to be installed and used by openfoam.
@@ -96,9 +99,9 @@ RUN apt-get update -qq\
 #AEG:These libraries are needed for CGAL (system and third party) (if needed, change libgmp-dev for libgmp3-dev):
 #NotIn8:   libgmp-dev libmpfr-dev\
 #AEG:Wiki additional qt suggestions:
-   qtbase5-dev \
+   #qtbase5-dev \
 #AEG: Some more suggestions from the wiki instructions:
-   python python-dev \
+   python3 python3-dev \
    libglu1-mesa-dev \
 #AEG:I found the following was needed to install  FlexLexer.hi (now included in the wiki instructions too):
    libfl-dev \
@@ -189,6 +192,15 @@ ARG BASHRC_OPTIONS=""
 #                            So, if needed, will first be tried to install with apt-get at the top of this recipe.
 #                            It seems that "foamyHexMesh" has been deprecated, so CGAL seems not to be needed.
 
+#CMEYER: Patch files for fix to sha1 overload problem
+#CMEYER: see https://develop.openfoam.com/Development/openfoam/-/issues/2496
+#CMEYER: see https://develop.openfoam.com/Development/openfoam/-/commit/eb3f7dfe7443fe852b256072f337ac24effff0ac
+RUN . ${OFBASHRC} \
+ && cd ${WM_PROJECT_DIR}
+WORKDIR /opt/OpenFOAM/OpenFOAM-8
+COPY sha1-fix.patch /tmp/sha1-fix.patch
+RUN patch -p1 < /tmp/sha1-fix.patch
+
 #Third party compilation
 RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
  && cd $WM_THIRD_PARTY_DIR \
@@ -201,24 +213,31 @@ RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
 #Install paraview for graphical postprocessing to be available in the container
 #Catalyst tools are not available for the foundation version
 
+# CMEYER: Paraview is failing to build in ubuntu24.04 with default Python and Compiler. So Paraview (or paraFoam) will not work inside this container. 
+# If there is still interest to compile it, the recommendation is to try installing an old verion of Python and gcc and attempt compilation again or else
+# upgrade to ParaView/6.0.0, which compiles fine with default python and compilers in container, but may have runtime issues with older openfoam 
+# due to how comparaitvely new it is
 #AEG: foundation source files do not count with makeVTK script, so will not attempt to install VTK
-
 #Downloading first ParaView with wget because automatic download with curl is failing
 #(Paraview download address copy/pasted from ThirdParty-<Version>/README.org)
-ARG PVverFull="5.6.3"
-ARG PVverMajor="5.6"
-RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
- && cd $WM_THIRD_PARTY_DIR \
- && export QT_SELECT=qt5 \
- && wget --no-check-certificate http://www.paraview.org/files/v${PVverMajor}/ParaView-v${PVverFull}.tar.gz \
- && tar xvf ParaView-v${PVverFull}.tar.gz \
- && rm ParaView-v${PVverFull}.tar.gz \
- && mv ParaView-v${PVverFull} ParaView-${PVverFull}
+# ARG PVverFull="5.6.3"
+# ARG PVverMajor="5.6"
+# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#  && cd $WM_THIRD_PARTY_DIR \
+#  && export QT_SELECT=qt5 \
+#  && wget --no-check-certificate http://www.paraview.org/files/v${PVverMajor}/ParaView-v${PVverFull}.tar.gz \
+#  && tar xvf ParaView-v${PVverFull}.tar.gz \
+#  && rm ParaView-v${PVverFull}.tar.gz \
+#  && mv ParaView-v${PVverFull} ParaView-${PVverFull}
 
 #Paraview compilation (according to instructions from the official site)
-RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
- && cd $WM_THIRD_PARTY_DIR \
- && ./makeParaView 2>&1 | tee log.makePVOfficial
+# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#  && cd $WM_THIRD_PARTY_DIR \
+#  && ./makeParaView \
+#    CMAKE_C_COMPILER=/usr/bin/gcc-9 CMAKE_CXX_COMPILER=/usr/bin/g++-9 \
+#    PYTHON_EXECUTABLE=/usr/local/bin/python2.7 PYTHON_INCLUDE_DIR=/usr/local/include/python2.7 \
+#    PYTHON_LIBRARY=/usr/local/lib/libpython2.7.so PYTHON_LIBRARY_DIR=/usr/local/lib/python2.7/config \
+#    -python -mpi -python-include /usr/local/include/python2.7 -python-lib /usr/local/lib/libpython2.7.so 2>&1 | tee log.makePV
 
 #NotFor8:#Paraview compilation (Using instructions from the wiki)
 #NotFor8:RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \

--- a/OpenFOAM/openfoam-org/8/Dockerfile
+++ b/OpenFOAM/openfoam-org/8/Dockerfile
@@ -218,26 +218,22 @@ RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
 # upgrade to ParaView/6.0.0, which compiles fine with default python and compilers in container, but may have runtime issues with older openfoam 
 # due to how comparaitvely new it is
 #AEG: foundation source files do not count with makeVTK script, so will not attempt to install VTK
-#Downloading first ParaView with wget because automatic download with curl is failing
-#(Paraview download address copy/pasted from ThirdParty-<Version>/README.org)
-# ARG PVverFull="5.6.3"
-# ARG PVverMajor="5.6"
-# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
-#  && cd $WM_THIRD_PARTY_DIR \
-#  && export QT_SELECT=qt5 \
-#  && wget --no-check-certificate http://www.paraview.org/files/v${PVverMajor}/ParaView-v${PVverFull}.tar.gz \
-#  && tar xvf ParaView-v${PVverFull}.tar.gz \
-#  && rm ParaView-v${PVverFull}.tar.gz \
-#  && mv ParaView-v${PVverFull} ParaView-${PVverFull}
+#NotForUb24.04#Downloading first ParaView with wget because automatic download with curl is failing
+#NotForUb24.04#(Paraview download address copy/pasted from ThirdParty-<Version>/README.org)
+#NotForUb24.04# ARG PVverFull="5.6.3"
+#NotForUb24.04# ARG PVverMajor="5.6"
+#NotForUb24.04# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#NotForUb24.04#  && cd $WM_THIRD_PARTY_DIR \
+#NotForUb24.04#  && export QT_SELECT=qt5 \
+#NotForUb24.04#  && wget --no-check-certificate http://www.paraview.org/files/v${PVverMajor}/ParaView-v${PVverFull}.tar.gz \
+#NotForUb24.04#  && tar xvf ParaView-v${PVverFull}.tar.gz \
+#NotForUb24.04#  && rm ParaView-v${PVverFull}.tar.gz \
+#NotForUb24.04#  && mv ParaView-v${PVverFull} ParaView-${PVverFull}
 
-#Paraview compilation (according to instructions from the official site)
-# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
-#  && cd $WM_THIRD_PARTY_DIR \
-#  && ./makeParaView \
-#    CMAKE_C_COMPILER=/usr/bin/gcc-9 CMAKE_CXX_COMPILER=/usr/bin/g++-9 \
-#    PYTHON_EXECUTABLE=/usr/local/bin/python2.7 PYTHON_INCLUDE_DIR=/usr/local/include/python2.7 \
-#    PYTHON_LIBRARY=/usr/local/lib/libpython2.7.so PYTHON_LIBRARY_DIR=/usr/local/lib/python2.7/config \
-#    -python -mpi -python-include /usr/local/include/python2.7 -python-lib /usr/local/lib/libpython2.7.so 2>&1 | tee log.makePV
+#NotForUb24.04#Paraview compilation (according to instructions from the official site)
+#NotForUb24.04# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#NotForUb24.04#  && cd $WM_THIRD_PARTY_DIR \
+#NotForUb24.04#  && ./makeParaView 2>&1 | tee log.makePVOfficial \
 
 #NotFor8:#Paraview compilation (Using instructions from the wiki)
 #NotFor8:RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \

--- a/OpenFOAM/openfoam-org/8/sha1-fix.patch
+++ b/OpenFOAM/openfoam-org/8/sha1-fix.patch
@@ -1,0 +1,76 @@
+--- a/src/OpenFOAM/db/IOstreams/hashes/OSHA1stream.H
++++ b/src/OpenFOAM/db/IOstreams/hashes/OSHA1stream.H
+@@ -32,8 +32,8 @@
+ 
+ \*---------------------------------------------------------------------------*/
+ 
+-#ifndef OSHA1stream_H
+-#define OSHA1stream_H
++#ifndef Foam_OSHA1stream_H
++#define Foam_OSHA1stream_H
+ 
+ #include "OSstream.H"
+ #include "SHA1.H"
+@@ -62,6 +62,15 @@
+ 
+     friend class osha1stream;
+ 
++protected:
++
++    //- Handle overflow
++    virtual int overflow(int c = EOF)
++    {
++        if (c != EOF) sha1_.append(c);
++        return c;
++    }
++
+ public:
+ 
+     // Constructors
+@@ -77,7 +86,7 @@
+         //- Process unbuffered
+         virtual std::streamsize xsputn(const char* str, std::streamsize n)
+         {
+-            sha1_.append(str, n);
++            if (n) sha1_.append(str, n);
+             return n;
+         }
+ };
+--- a/src/OpenFOAM/primitives/hashes/SHA1/SHA1.H
++++ b/src/OpenFOAM/primitives/hashes/SHA1/SHA1.H
+@@ -39,8 +39,8 @@
+ 
+ \*---------------------------------------------------------------------------*/
+ 
+-#ifndef SHA1_H
+-#define SHA1_H
++#ifndef Foam_SHA1_H
++#define Foam_SHA1_H
+ 
+ #include <string>
+ #include <cstddef>
+@@ -126,6 +126,9 @@
+         //- Reset the hashed data before appending more
+         void clear();
+ 
++        //- Append single character
++        inline void append(char c);
++
+         //- Append data for processing
+         inline SHA1& append(const char* data, size_t len);
+ 
+--- a/src/OpenFOAM/primitives/hashes/SHA1/SHA1I.H
++++ b/src/OpenFOAM/primitives/hashes/SHA1/SHA1I.H
+@@ -50,6 +50,12 @@
+ 
+ // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+ 
++inline void Foam::SHA1::append(char c)
++{
++    processBytes(&c, 1);
++}
++
++
+ inline Foam::SHA1& Foam::SHA1::append(const char* data, size_t len)
+ {
+     processBytes(data, len);

--- a/OpenFOAM/openfoam-org/9/Dockerfile
+++ b/OpenFOAM/openfoam-org/9/Dockerfile
@@ -195,22 +195,22 @@ RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
 # If there is still interest to compile it, the recommendation is to try installing an old verion of Python and gcc and attempt compilation again or else
 # upgrade to ParaView/6.0.0, which compiles fine with default python and compilers in container, but may have runtime issues with older openfoam 
 # due to how comparatively new it is
-#Downloading first ParaView with wget because automatic download with curl is failing
-#(Paraview download address copy/pasted from ThirdParty-<Version>/README.org)
-# ARG PVverFull="5.6.3"
-# ARG PVverMajor="5.6"
-# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
-#  && cd $WM_THIRD_PARTY_DIR \
-#  && export QT_SELECT=qt5 \
-#  && wget --no-check-certificate http://www.paraview.org/files/v${PVverMajor}/ParaView-v${PVverFull}.tar.gz \
-#  && tar xvf ParaView-v${PVverFull}.tar.gz \
-#  && rm ParaView-v${PVverFull}.tar.gz \
-#  && mv ParaView-v${PVverFull} ParaView-${PVverFull}
+#NotForUb24.04#Downloading first ParaView with wget because automatic download with curl is failing
+#NotForUb24.04#(Paraview download address copy/pasted from ThirdParty-<Version>/README.org)
+#NotForUb24.04# ARG PVverFull="5.6.3"
+#NotForUb24.04# ARG PVverMajor="5.6"
+#NotForUb24.04# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#NotForUb24.04#  && cd $WM_THIRD_PARTY_DIR \
+#NotForUb24.04#  && export QT_SELECT=qt5 \
+#NotForUb24.04#  && wget --no-check-certificate http://www.paraview.org/files/v${PVverMajor}/ParaView-v${PVverFull}.tar.gz \
+#NotForUb24.04#  && tar xvf ParaView-v${PVverFull}.tar.gz \
+#NotForUb24.04#  && rm ParaView-v${PVverFull}.tar.gz \
+#NotForUb24.04#  && mv ParaView-v${PVverFull} ParaView-${PVverFull}
 
-# #Paraview compilation (according to instructions from the official site)
-# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
-#  && cd $WM_THIRD_PARTY_DIR \
-#  && ./makeParaView 2>&1 | tee log.makePVOfficial
+#NotForUb24.04# #Paraview compilation (according to instructions from the official site)
+#NotForUb24.04# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#NotForUb24.04#  && cd $WM_THIRD_PARTY_DIR \
+#NotForUb24.04#  && ./makeParaView 2>&1 | tee log.makePVOfficial
 
 #NotFor8:#Paraview compilation (Using instructions from the wiki)
 #NotFor8:RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \

--- a/OpenFOAM/openfoam-org/9/Dockerfile
+++ b/OpenFOAM/openfoam-org/9/Dockerfile
@@ -4,8 +4,8 @@
 # 0. Initial main definition
 # Defining the base container to build from
 # IMPORTANT: 
-# Setonix needs at least ubuntu20.04 (From August 2023)
-FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu20.04
+# Setonix needs at least ubuntu24.04 (From August 2025)
+FROM quay.io/pawsey/mpich-base:3.4.3_ubuntu24.04
 
 LABEL maintainer="Alexis.Espinosa@pawsey.org.au"
 #OpenFOAM version to install
@@ -43,8 +43,8 @@ RUN echo "root:${OFVERSION}" | chpasswd
 #Recent native developers' containers are not using this "ofuser" anymore, although it is still useful to have it
 #for pawsey purposes where /group needs to be used as the place for the *USER* variables. Then, /group directory
 #will be mounted into the ofuser dir whenever own compiled tools are used
-RUN groupadd -g 999 ofuser \
- && useradd -r -m -u 999 -g ofuser ofuser
+RUN groupadd -g 10001 ofuser \
+ && useradd -r -m -u 10001 -g ofuser ofuser
 RUN echo "ofuser:${OFVERSION}" | chpasswd
 
 
@@ -88,8 +88,11 @@ RUN apt-get update -qq\
     build-essential cmake git ca-certificates \
     flex libfl-dev bison zlib1g-dev libboost-system-dev libboost-thread-dev \
 #AEG:No openMPI as MPICH is to be used:    libopenmpi-dev openmpi-bin \
-    gnuplot libreadline-dev libncurses-dev libxt-dev \
-    libqt5x11extras5-dev libxt-dev qt5-default qttools5-dev curl \
+    gnuplot libreadline-dev libncurses-dev \
+#AEG: CMEYER suggestion:replace qt5-default by the expanded set of qt5 libraries for ubuntu24.04
+    #qt5-default \
+    qtbase5-dev qttools5-dev qttools5-dev-tools qtchooser qt5-qmake qtbase5-dev-tools libqt5opengl5-dev libqt5x11extras5-dev libxt-dev \
+    curl \
  && apt-get clean all \
  && rm -r /var/lib/apt/lists/*
 

--- a/OpenFOAM/openfoam-org/9/Dockerfile
+++ b/OpenFOAM/openfoam-org/9/Dockerfile
@@ -191,22 +191,26 @@ RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
 
 #AEG: foundation source files do not count with makeVTK script, so will not attempt to install VTK
 
+# CMEYER: Paraview is failing to build in ubuntu24.04 with default Python and Compiler. So Paraview (or paraFoam) will not work inside this container. 
+# If there is still interest to compile it, the recommendation is to try installing an old verion of Python and gcc and attempt compilation again or else
+# upgrade to ParaView/6.0.0, which compiles fine with default python and compilers in container, but may have runtime issues with older openfoam 
+# due to how comparatively new it is
 #Downloading first ParaView with wget because automatic download with curl is failing
 #(Paraview download address copy/pasted from ThirdParty-<Version>/README.org)
-ARG PVverFull="5.6.3"
-ARG PVverMajor="5.6"
-RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
- && cd $WM_THIRD_PARTY_DIR \
- && export QT_SELECT=qt5 \
- && wget --no-check-certificate http://www.paraview.org/files/v${PVverMajor}/ParaView-v${PVverFull}.tar.gz \
- && tar xvf ParaView-v${PVverFull}.tar.gz \
- && rm ParaView-v${PVverFull}.tar.gz \
- && mv ParaView-v${PVverFull} ParaView-${PVverFull}
+# ARG PVverFull="5.6.3"
+# ARG PVverMajor="5.6"
+# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#  && cd $WM_THIRD_PARTY_DIR \
+#  && export QT_SELECT=qt5 \
+#  && wget --no-check-certificate http://www.paraview.org/files/v${PVverMajor}/ParaView-v${PVverFull}.tar.gz \
+#  && tar xvf ParaView-v${PVverFull}.tar.gz \
+#  && rm ParaView-v${PVverFull}.tar.gz \
+#  && mv ParaView-v${PVverFull} ParaView-${PVverFull}
 
-#Paraview compilation (according to instructions from the official site)
-RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
- && cd $WM_THIRD_PARTY_DIR \
- && ./makeParaView 2>&1 | tee log.makePVOfficial
+# #Paraview compilation (according to instructions from the official site)
+# RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \
+#  && cd $WM_THIRD_PARTY_DIR \
+#  && ./makeParaView 2>&1 | tee log.makePVOfficial
 
 #NotFor8:#Paraview compilation (Using instructions from the wiki)
 #NotFor8:RUN . ${OFBASHRC} ${BASHRC_OPTIONS} \


### PR DESCRIPTION
These are updates to the dockerfiles for rebuilds of the openfoam-org:7, openfoam-org:8, and openfoam-org:9 containers. The updates are:

All dockerfiles

- Using ubuntu/24.04 base image
- Install an expanded set of qt5 libraries for ubuntu24.04, since `qt5-default` failed
- Change the group ID of the `ofuser` to 10001
- Commenting out `paraview/5.6.x` installation due to installation difficulties in ubuntu/24.04

openfoam-org:8 and openfoam-org:7

- Patching several files to fix sha1-overload problem which leads to I/O errors at runtime. See https://develop.openfoam.com/Development/openfoam/-/issues/2496 for details of the issue, error, and fix

openfoam-org:7

- Install `cgal/4.10` from source since `libcgal-dev` packaged with ubuntu/24.04 conflicts with what openfoam 7 expects (e.g. header files having changed names)