### PR TITLE
Fixing testing launcher to have only 1 list of tests

### DIFF
--- a/setonix/mpi/mpich-base/testing/run_tests.sh
+++ b/setonix/mpi/mpich-base/testing/run_tests.sh
@@ -144,6 +144,7 @@ export OUTPUT_DIR="${OUTPUT_DIR}"
 
 FAILED=0
 declare -a TEST_JOB_IDS=()
+declare -a TEST_NAMES=()
 PREVIOUS_JOB_ID=""
 
 print_test_warnings() {
@@ -189,6 +190,7 @@ run_slurm_test() {
     test_script_abs="$(realpath "${test_script}")"
     test_file="$(basename "${test_script_abs}")"
     test_name="${test_file%.slurm.sh}"
+    TEST_NAMES+=("${test_name}")
 
     marker_pass="${OUTPUT_DIR}/${test_name}.PASS"
     marker_fail="${OUTPUT_DIR}/${test_name}.FAIL"
@@ -240,13 +242,22 @@ run_slurm_test() {
     echo "Slurm output file: ${OUTPUT_DIR}/slurm-${test_name}-${job_id}.out"
 }
 
+# Test specification format:
+# <test_script>|<number_of_nodes>|<tasks_per_node>
+#
+# Comment out an entry to disable that test.
+declare -a TEST_SPECS=(
+    "${SHARED_TESTS_DIR}/test_01_compile+run.slurm.sh|2|4"
+    "${SHARED_TESTS_DIR}/test_02_osu.slurm.sh|2|4"
+    "${SHARED_TESTS_DIR}/test_03_mpi4py.slurm.sh|2|4"
+    "${SHARED_TESTS_DIR}/test_04_mpi-comm.slurm.sh|2|8"
+)
 
 # Run all tests:
-# Use: run_slurm_test <test_script> <number_of_nodes> <tasks_per_node>
-run_slurm_test "${SHARED_TESTS_DIR}/test_01_compile+run.slurm.sh" 2 4
-run_slurm_test "${SHARED_TESTS_DIR}/test_02_osu.slurm.sh" 2 4
-run_slurm_test "${SHARED_TESTS_DIR}/test_03_mpi4py.slurm.sh" 2 4
-run_slurm_test "${SHARED_TESTS_DIR}/test_04_mpi-comm.slurm.sh" 2 8
+for test_spec in "${TEST_SPECS[@]}"; do
+    IFS='|' read -r test_script number_of_nodes tasks_per_node <<< "${test_spec}"
+    run_slurm_test "${test_script}" "${number_of_nodes}" "${tasks_per_node}"
+done
 
 job_id_list="$(IFS=,; echo "${TEST_JOB_IDS[@]}")"
 
@@ -273,12 +284,7 @@ done
 
 echo "All submitted tests have finished."
 
-for test_name in \
-    "test_01_compile+run" \
-    "test_02_osu" \
-    "test_03_mpi4py" \
-    "test_04_mpi-comm"
-do
+for test_name in "${TEST_NAMES[@]}"; do
     marker_pass="${OUTPUT_DIR}/${test_name}.PASS"
     marker_fail="${OUTPUT_DIR}/${test_name}.FAIL"
     marker_warn="${OUTPUT_DIR}/${test_name}.WARN"


### PR DESCRIPTION
I have modified the `setonix/mpi/mpich-base/testing/run_tests.sh` launcher script for it to have only one list of tests to perform. This is now better design.

I have tested the new launcher script works fine:
```
espinosa@joey-02:/scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing> ./run_tests.sh 
============================================================
mpich-base Slurm test launcher
============================================================
Repository root      : /scratch/pawsey0001/espinosa/pawsey-containers
Run ID               : 20260811T040440Z-1590657
Artifacts directory  : /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657
MPI directory        : /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi
Launcher directory   : /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing
Shared tests directory: /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/tests
Fixtures directory   : /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/tests/fixtures
Tests support dir    : /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/tests/tests-support
Image                : /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/artifacts/singularityImages/mpich-base--mpich4.2.2-ubuntu24.04.sif
Singularity module   : singularity/4.1.0-mpi
Partition            : work
Execution mode       : sequential
Reservation          : none
Build directory      : /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/build
Output directory     : /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/output


Submitting: /lus/joey/scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/tests/test_01_compile+run.slurm.sh
Test name : test_01_compile+run
Nodes     : 2
Tasks/node: 4
Submitted job: 384155
Output directory: /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/output
Slurm output file: /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/output/slurm-test_01_compile+run-384155.out

Submitting: /lus/joey/scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/tests/test_02_osu.slurm.sh
Test name : test_02_osu
Nodes     : 2
Tasks/node: 4
Submitted job: 384156
Output directory: /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/output
Slurm output file: /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/output/slurm-test_02_osu-384156.out

Submitting: /lus/joey/scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/tests/test_03_mpi4py.slurm.sh
Test name : test_03_mpi4py
Nodes     : 2
Tasks/node: 4
Submitted job: 384157
Output directory: /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/output
Slurm output file: /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/output/slurm-test_03_mpi4py-384157.out

Submitting: /lus/joey/scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/tests/test_04_mpi-comm.slurm.sh
Test name : test_04_mpi-comm
Nodes     : 2
Tasks/node: 8
Submitted job: 384158
Output directory: /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/output
Slurm output file: /scratch/pawsey0001/espinosa/pawsey-containers/setonix/mpi/mpich-base/testing/artifacts/runs/20260811T040440Z-1590657/output/slurm-test_04_mpi-comm-384158.out

Waiting for all submitted tests to finish...
Job IDs: 384155 384156 384157 384158
Tests still pending or running: 4
Tests still pending or running: 3
Tests still pending or running: 2
Tests still pending or running: 1
All submitted tests have finished.

PASS: test_01_compile+run

PASS: test_02_osu

PASS: test_03_mpi4py

PASS: test_04_mpi-comm

============================================================
Test summary
============================================================
RESULT: PASS
All enabled tests passed.
```