### PR TITLE
Updating labels in the recipes

### DIFF
--- a/setonix/mpi/lustrempich-base/buildlustrempich.dockerfile
+++ b/setonix/mpi/lustrempich-base/buildlustrempich.dockerfile
@@ -286,14 +286,16 @@ ARG IMAGE_BUILD_INFO_DIR
 
 #---------------------------------------------------------------
 # G.1 Defining documented labels
+ARG IMAGE_TITLE="mpich-lustre-base"
 LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>, Deva Deeptimahanti <deva.deeptimahanti@pawsey.org.au>"
-LABEL org.opencontainers.image.title="mpich-lustre-base"
+LABEL org.opencontainers.image.title="${IMAGE_TITLE}"
 LABEL org.opencontainers.image.version="mpich${MPICH_VERSION}-lustre${LUSTRE_VERSION}-ubuntu${OS_VERSION}"
 LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers"
 LABEL au.org.pawsey.image.build-info-dir="${IMAGE_BUILD_INFO_DIR}"
 
 #---------------------------------------------------------------
 # G.2 Copy the recipe into the docker recipes directory
+ARG INTERNAL_BUILD_INFO_SUBDIR="${IMAGE_BUILD_INFO_DIR}/${IMAGE_TITLE}"
 RUN set -eux; \
-    mkdir -p "${IMAGE_BUILD_INFO_DIR}"
-COPY buildlustrempich.dockerfile "${IMAGE_BUILD_INFO_DIR}"
+    mkdir -p "${INTERNAL_BUILD_INFO_SUBDIR}"
+COPY buildlustrempich.dockerfile "${INTERNAL_BUILD_INFO_SUBDIR}"

--- a/setonix/mpi/lustrempich-base/buildlustrempich.dockerfile
+++ b/setonix/mpi/lustrempich-base/buildlustrempich.dockerfile
@@ -32,7 +32,7 @@ ARG LINUX_KERNEL="6.8.0-31"
 ARG LUSTRE_VERSION="release"
 
 # 0.2 Other auxiliary variables to ease building
-ARG DOCKER_RECIPES_DIR="/opt/docker-recipes"
+ARG IMAGE_BUILD_INFO_DIR="/opt/build-info-and-recipes"
 
 
 #---------------------------------------------------------------
@@ -42,23 +42,11 @@ ARG DOCKER_RECIPES_DIR="/opt/docker-recipes"
 FROM ${BASE_IMAGE_FULL} AS basic_stage
 #---------------------------------------------------------------
 # A.0 Recall global definitions made at the top
-ARG MPICH_VERSION
-ARG OS_VERSION
-ARG DOCKER_RECIPES_DIR
 ARG GCC_VERSION
 ARG LINUX_KERNEL
-ARG LUSTRE_VERSION
 
 #---------------------------------------------------------------
-# A.1 Defining documented labels
-LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>, Deva Deeptimahanti <deva.deeptimahanti@pawsey.org.au>"
-LABEL org.opencontainers.image.name="mpich-lustre-base"
-LABEL org.opencontainers.image.branch="mpich${MPICH_VERSION}-lustre${LUSTRE_VERSION}-ubuntu${OS_VERSION}"
-LABEL org.opencontainers.image.dockerfile-internal-backup="${DOCKER_RECIPES_DIR}"
-LABEL org.opencontainers.image.git-repository="https://github.com/PawseySC/pawsey-containers"
-
-#---------------------------------------------------------------
-# A.2 Installing basic requirements
+# A.1 Installing basic requirements
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
@@ -207,7 +195,6 @@ RUN set -eux; \
     rm -rf /tmp/mpich-build
 
 
-
 #---------------------------------------------------------------
 #---------------------------------------------------------------
 #---------------------------------------------------------------
@@ -292,10 +279,21 @@ RUN set -eux; \
 FROM other_tests AS final_settings
 #---------------------------------------------------------------
 # G.0 Recall global definitions made at the top
-ARG DOCKER_RECIPES_DIR
+ARG MPICH_VERSION
+ARG OS_VERSION
+ARG LUSTRE_VERSION
+ARG IMAGE_BUILD_INFO_DIR
 
 #---------------------------------------------------------------
-# G.1 Copy the recipe into the docker recipes directory
+# G.1 Defining documented labels
+LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>, Deva Deeptimahanti <deva.deeptimahanti@pawsey.org.au>"
+LABEL org.opencontainers.image.title="mpich-lustre-base"
+LABEL org.opencontainers.image.version="mpich${MPICH_VERSION}-lustre${LUSTRE_VERSION}-ubuntu${OS_VERSION}"
+LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers"
+LABEL au.org.pawsey.image.build-info-dir="${IMAGE_BUILD_INFO_DIR}"
+
+#---------------------------------------------------------------
+# G.2 Copy the recipe into the docker recipes directory
 RUN set -eux; \
-    mkdir -p "${DOCKER_RECIPES_DIR}"
-COPY buildlustrempich.dockerfile "${DOCKER_RECIPES_DIR}"
+    mkdir -p "${IMAGE_BUILD_INFO_DIR}"
+COPY buildlustrempich.dockerfile "${IMAGE_BUILD_INFO_DIR}"

--- a/setonix/mpi/mpich-base/buildmpich.dockerfile
+++ b/setonix/mpi/mpich-base/buildmpich.dockerfile
@@ -207,14 +207,16 @@ ARG IMAGE_BUILD_INFO_DIR
 
 #---------------------------------------------------------------
 # F.1 Defining documented labels
+ARG IMAGE_TITLE="mpich-base"
 LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>, Deva Deeptimahanti <deva.deeptimahanti@pawsey.org.au>"
-LABEL org.opencontainers.image.title="mpich-base"
+LABEL org.opencontainers.image.title="${IMAGE_TITLE}"
 LABEL org.opencontainers.image.version="mpich${MPICH_VERSION}-ubuntu${OS_VERSION}"
 LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers"
 LABEL au.org.pawsey.image.build-info-dir="${IMAGE_BUILD_INFO_DIR}"
 
 #---------------------------------------------------------------
 # F.2 Copy the recipe into the docker recipes directory
+ARG INTERNAL_BUILD_INFO_SUBDIR="${IMAGE_BUILD_INFO_DIR}/${IMAGE_TITLE}"
 RUN set -eux; \
-    mkdir -p "${IMAGE_BUILD_INFO_DIR}"
-COPY buildmpich.dockerfile "${IMAGE_BUILD_INFO_DIR}"
+    mkdir -p "${INTERNAL_BUILD_INFO_SUBDIR}"
+COPY buildmpich.dockerfile "${INTERNAL_BUILD_INFO_SUBDIR}"

--- a/setonix/mpi/mpich-base/buildmpich.dockerfile
+++ b/setonix/mpi/mpich-base/buildmpich.dockerfile
@@ -25,7 +25,7 @@ ARG OSU_BENCHMARKS_VERSION="7.3"
 ARG PROFILE_UTIL_VERSION="main"
 
 # 0.2 Other auxiliary variables to ease building
-ARG DOCKER_RECIPES_DIR="/opt/docker-recipes"
+ARG IMAGE_BUILD_INFO_DIR="/opt/build-info-and-recipes"
 
 
 #---------------------------------------------------------------
@@ -35,20 +35,9 @@ ARG DOCKER_RECIPES_DIR="/opt/docker-recipes"
 FROM ${BASE_IMAGE_FULL} AS basic_stage
 #---------------------------------------------------------------
 # A.0 Recall global definitions made at the top
-ARG MPICH_VERSION
-ARG OS_VERSION
-ARG DOCKER_RECIPES_DIR
 
 #---------------------------------------------------------------
-# A.1 Defining documented labels
-LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>, Deva Deeptimahanti <deva.deeptimahanti@pawsey.org.au>"
-LABEL org.opencontainers.image.name="mpich-base"
-LABEL org.opencontainers.image.branch="mpich${MPICH_VERSION}-ubuntu${OS_VERSION}"
-LABEL org.opencontainers.image.dockerfile-internal-backup="${DOCKER_RECIPES_DIR}"
-LABEL org.opencontainers.image.git-repository="https://github.com/PawseySC/pawsey-containers"
-
-#---------------------------------------------------------------
-# A.2 Installing basic requirements
+# A.1 Installing basic requirements
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
@@ -116,7 +105,7 @@ ARG MPICH_MAKE_OPTIONS="-j16"
 RUN set -eux; \
     mkdir -p /tmp/mpich-build; \
     cd /tmp/mpich-build; \
-    wget "https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz"; \
+    wget --no-hsts "https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz"; \
     echo "${MPICH_SHA256}  mpich-${MPICH_VERSION}.tar.gz" | sha256sum -c -; \
     tar xzvf "mpich-${MPICH_VERSION}.tar.gz"; \
     cd "mpich-${MPICH_VERSION}"; \
@@ -164,7 +153,7 @@ ARG OSU_MAKE_OPTIONS="-j8"
 RUN set -eux; \
     mkdir -p /tmp/osu-benchmark-build; \
     cd /tmp/osu-benchmark-build; \
-    wget "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-${OSU_BENCHMARKS_VERSION}.tar.gz"; \
+    wget --no-hsts "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-${OSU_BENCHMARKS_VERSION}.tar.gz"; \
     tar xzvf "osu-micro-benchmarks-${OSU_BENCHMARKS_VERSION}.tar.gz"; \
     cd "osu-micro-benchmarks-${OSU_BENCHMARKS_VERSION}"; \
     ./configure ${OSU_CONFIGURE_OPTIONS}; \
@@ -208,14 +197,24 @@ RUN set -eux; \
 #---------------------------------------------------------------
 #---------------------------------------------------------------
 #---------------------------------------------------------------
-# H. Final settings
+# F. Final settings
 FROM other_tests AS final_settings
 #---------------------------------------------------------------
-# H.0 Recall global definitions made at the top
-ARG DOCKER_RECIPES_DIR
+# F.0 Recall global definitions made at the top
+ARG MPICH_VERSION
+ARG OS_VERSION
+ARG IMAGE_BUILD_INFO_DIR
 
 #---------------------------------------------------------------
-# H.1 Copy the recipe into the docker recipes directory
+# F.1 Defining documented labels
+LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>, Deva Deeptimahanti <deva.deeptimahanti@pawsey.org.au>"
+LABEL org.opencontainers.image.title="mpich-base"
+LABEL org.opencontainers.image.version="mpich${MPICH_VERSION}-ubuntu${OS_VERSION}"
+LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers"
+LABEL au.org.pawsey.image.build-info-dir="${IMAGE_BUILD_INFO_DIR}"
+
+#---------------------------------------------------------------
+# F.2 Copy the recipe into the docker recipes directory
 RUN set -eux; \
-    mkdir -p "${DOCKER_RECIPES_DIR}"
-COPY buildmpich.dockerfile "${DOCKER_RECIPES_DIR}"
+    mkdir -p "${IMAGE_BUILD_INFO_DIR}"
+COPY buildmpich.dockerfile "${IMAGE_BUILD_INFO_DIR}"

--- a/setonix/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
+++ b/setonix/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
@@ -537,14 +537,16 @@ RUN set -eux; \
 
 #---------------------------------------------------------------
 # L.3 Defining documented labels
+ARG IMAGE_TITLE="rocm-mpich-base"
 LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>, Deva Deeptimahanti <deva.deeptimahanti@pawsey.org.au>"
-LABEL org.opencontainers.image.title="rocm-mpich-base"
+LABEL org.opencontainers.image.title="${IMAGE_TITLE}"
 LABEL org.opencontainers.image.version="rocm${ROCM_VERSION}-mpich${MPICH_VERSION}-lustre${LUSTRE_VERSION}-ubuntu${OS_VERSION}"
 LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers"
 LABEL au.org.pawsey.image.build-info-dir="${IMAGE_BUILD_INFO_DIR}"
 
 #---------------------------------------------------------------
 # L.4 Copy the recipe into the docker recipes directory
+ARG INTERNAL_BUILD_INFO_SUBDIR="${IMAGE_BUILD_INFO_DIR}/${IMAGE_TITLE}"
 RUN set -eux; \
-    mkdir -p "${IMAGE_BUILD_INFO_DIR}"
-COPY buildrocm-mpich-base.dockerfile "${IMAGE_BUILD_INFO_DIR}"
+    mkdir -p "${INTERNAL_BUILD_INFO_SUBDIR}"
+COPY buildrocm-mpich-base.dockerfile "${INTERNAL_BUILD_INFO_SUBDIR}"

--- a/setonix/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
+++ b/setonix/mpi/rocm-mpich-base/buildrocm-mpich-base.dockerfile
@@ -45,7 +45,7 @@ ARG ARCH="amd64"
 ARG GFX_ARCH="gfx90a"
 
 # 0.2 Other auxiliary variables to ease building
-ARG DOCKER_RECIPES_DIR="/opt/docker-recipes"
+ARG IMAGE_BUILD_INFO_DIR="/opt/build-info-and-recipes"
 
 
 #---------------------------------------------------------------
@@ -55,24 +55,11 @@ ARG DOCKER_RECIPES_DIR="/opt/docker-recipes"
 FROM ${BASE_IMAGE_FULL} AS basic_stage
 #---------------------------------------------------------------
 # A.0 Recall global definitions made at the top
-ARG MPICH_VERSION
-ARG OS_VERSION
-ARG DOCKER_RECIPES_DIR
 ARG GCC_VERSION
 ARG LINUX_KERNEL
-ARG ROCM_VERSION
-ARG LUSTRE_VERSION
 
 #---------------------------------------------------------------
-# A.1 Defining documented labels
-LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>, Deva Deeptimahanti <deva.deeptimahanti@pawsey.org.au>"
-LABEL org.opencontainers.image.name="rocm-mpich-base"
-LABEL org.opencontainers.image.branch="rocm${ROCM_VERSION}-mpich${MPICH_VERSION}-lustre${LUSTRE_VERSION}-ubuntu${OS_VERSION}"
-LABEL org.opencontainers.image.dockerfile-internal-backup="${DOCKER_RECIPES_DIR}"
-LABEL org.opencontainers.image.git-repository="https://github.com/PawseySC/pawsey-containers"
-
-#---------------------------------------------------------------
-# A.2 Installing basic requirements
+# A.1 Installing basic requirements
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
@@ -525,7 +512,11 @@ RUN set -eux; \
 FROM other_tests AS final_settings
 #---------------------------------------------------------------
 # L.0 Recall global definitions made at the top
-ARG DOCKER_RECIPES_DIR
+ARG MPICH_VERSION
+ARG OS_VERSION
+ARG LUSTRE_VERSION
+ARG ROCM_VERSION
+ARG IMAGE_BUILD_INFO_DIR
 
 #---------------------------------------------------------------
 # L.1 Set some environment variables related to gpu communication and libfabric
@@ -534,6 +525,7 @@ ENV ROCM_PATH=/opt/rocm
 ENV HSA_FORCE_FINE_GRAIN_PCIE=1
 ENV FI_CXI_DISABLE_CQ_HUGETLB=1
 
+#---------------------------------------------------------------
 # L.2 Singularity: will execute scripts in /.singularity.d/env/ at startup (and ignore those in /etc/profile.d/).
 #              Standard naming of "environment" scripts is 9X-environment.sh
 RUN mkdir -p /.singularity.d/env/
@@ -543,7 +535,16 @@ RUN set -eux; \
     echo "export HSA_FORCE_FINE_GRAIN_PCIE=${HSA_FORCE_FINE_GRAIN_PCIE}" >> /.singularity.d/env/91-environment.sh; \
     echo "export FI_CXI_DISABLE_CQ_HUGETLB=${FI_CXI_DISABLE_CQ_HUGETLB}" >> /.singularity.d/env/91-environment.sh
 
-# L.3 Copy the recipe into the docker recipes directory
+#---------------------------------------------------------------
+# L.3 Defining documented labels
+LABEL org.opencontainers.image.authors="Pascal Jahan Elahi <pascal.elahi@pawsey.org.au>, Alexis Espinosa <alexis.espinosa@pawsey.org.au>, Craig Meyer <cmeyer@pawsey.org.au>, Deva Deeptimahanti <deva.deeptimahanti@pawsey.org.au>"
+LABEL org.opencontainers.image.title="rocm-mpich-base"
+LABEL org.opencontainers.image.version="rocm${ROCM_VERSION}-mpich${MPICH_VERSION}-lustre${LUSTRE_VERSION}-ubuntu${OS_VERSION}"
+LABEL org.opencontainers.image.source="https://github.com/PawseySC/pawsey-containers"
+LABEL au.org.pawsey.image.build-info-dir="${IMAGE_BUILD_INFO_DIR}"
+
+#---------------------------------------------------------------
+# L.4 Copy the recipe into the docker recipes directory
 RUN set -eux; \
-    mkdir -p "${DOCKER_RECIPES_DIR}"
-COPY buildrocm-mpich-base.dockerfile "${DOCKER_RECIPES_DIR}"
+    mkdir -p "${IMAGE_BUILD_INFO_DIR}"
+COPY buildrocm-mpich-base.dockerfile "${IMAGE_BUILD_INFO_DIR}"


### PR DESCRIPTION
Labels used in the recipes have been moved to the latest stage and their naming is now in line with the Pawsey best practices (which are in line with best practices of the OCI).

The directory to keep the docker recipe file respects the best practices definition: `/opt/build-info-and-recipes` and uses an additional subdirectory for better organization (even if it is not compulsory). So the dockerfile ends in the directory `/opt/build-info-recipes/mpich-base`, etc.